### PR TITLE
Disable MSVC warnings for duktape & yoga

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -31,6 +31,16 @@
 #define DUK_USE_DATE_NOW_WINDOWS 1
 #endif
 
+// Disable compiler warnings for external source files (duktape & yoga)
+#if _MSC_VER
+  #pragma warning(push)
+  #pragma warning(disable : 4018) // signed/unsigned mismatch
+  #pragma warning(disable : 4127) // conditional expression is constant
+  #pragma warning(disable : 4505) // unreferenced local function
+  #pragma warning(disable : 4611) // object destruction is non-portable
+  #pragma warning(disable : 4702) // unreachable code
+#endif
+
 #include "duktape/src-noline/duktape.c"
 #include "duktape/extras/console/duk_console.c"
 
@@ -46,6 +56,11 @@
 #include "yoga/yoga/YGStyle.cpp"
 #include "yoga/yoga/YGValue.cpp"
 #include "yoga/yoga/Yoga.cpp"
+
+// Enable compiler warnings
+#if _MSC_VER
+ #pragma warning (pop)
+#endif
 
 #include "core/blueprint_ReactApplicationRoot.cpp"
 #include "core/blueprint_ShadowView.cpp"


### PR DESCRIPTION
## Problem
On Visual Studio 2017 `duktape` produces a lot of compiler warnings. (80-100) 

## Fix
I'm using pragmas to turn them off, but only for external code, so `duktape` & `yoga`. The JUCE team is doing the same thing for the Steinberg `vst-sdk` in [juce_audio_processors/format_types/juce_VST3Headers.h](https://github.com/WeAreROLI/JUCE/blob/master/modules/juce_audio_processors/format_types/juce_VST3Headers.h)

```cpp
// Disable compiler warnings for external source files (duktape & yoga)
#if _MSC_VER
  #pragma warning(push)
  #pragma warning(disable : 4018) // signed/unsigned mismatch
  #pragma warning(disable : 4127) // conditional expression is constant
  #pragma warning(disable : 4505) // unreferenced local function
  #pragma warning(disable : 4611) // object destruction is non-portable
  #pragma warning(disable : 4702) // unreachable code
#endif

// include external *.cpp

// Enable compiler warnings
#if _MSC_VER
 #pragma warning (pop)
#endif
```