### PR TITLE
Added a HotReloader for refreshing ReactApplicationRoot

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -64,6 +64,7 @@
 
 #include "core/blueprint_EcmascriptEngine.cpp"
 #include "core/blueprint_GenericEditor.cpp"
+#include "core/blueprint_HotReloader.cpp"
 #include "core/blueprint_ReactApplicationRoot.cpp"
 #include "core/blueprint_ShadowView.cpp"
 #include "core/blueprint_TextShadowView.cpp"

--- a/blueprint/blueprint.h
+++ b/blueprint/blueprint.h
@@ -61,6 +61,7 @@
 #include "core/blueprint_ImageView.h"
 #include "core/blueprint_RawTextView.h"
 #include "core/blueprint_ReactApplicationRoot.h"
+#include "core/blueprint_HotReloader.h"
 #include "core/blueprint_ScrollView.h"
 #include "core/blueprint_ScrollViewContentShadowView.h"
 #include "core/blueprint_ShadowView.h"

--- a/blueprint/core/blueprint_HotReloader.cpp
+++ b/blueprint/core/blueprint_HotReloader.cpp
@@ -1,0 +1,69 @@
+/*
+  ==============================================================================
+
+    blueprint_HotRealoader.cpp
+    Created: 11 Dec 2019 2:20:29pm
+
+  ==============================================================================
+*/
+
+namespace blueprint
+{
+
+//==============================================================================
+HotReloader::HotReloader(std::unique_ptr<blueprint::ReactApplicationRoot> &appRoot, const juce::File &bundle, juce::Component &parentJuceComp) : root((std::unique_ptr<blueprint::ReactApplicationRoot> &)std::move(appRoot)), bundleFile(bundle), parentComp(parentJuceComp)
+{
+
+    // Sanity check
+    jassert(bundle.existsAsFile());
+    bundleFile = bundle;
+    lastModifiedTime = bundleFile.getLastModificationTime();
+
+    assignNewAppRoot(bundle.loadFileAsString());
+    startTimer(50);
+}
+
+HotReloader::~HotReloader()
+{
+    stopTimer();
+}
+
+void HotReloader::timerCallback()
+{
+    auto lmt = bundleFile.getLastModificationTime();
+
+    if (lmt > lastModifiedTime)
+    {
+        // Sanity check... again
+        jassert(bundleFile.existsAsFile());
+
+        // Remove and delete the current appRoot
+        root.reset();
+
+        // Then we assign a new one
+        assignNewAppRoot(bundleFile.loadFileAsString());
+
+        if (root)
+        {
+            parentComp.addAndMakeVisible(root.get());
+            root->setBounds(parentComp.getLocalBounds());
+        }
+
+        lastModifiedTime = lmt;
+    }
+}
+
+void HotReloader::assignNewAppRoot(const juce::String &code)
+{
+
+    root = std::make_unique<blueprint::ReactApplicationRoot>();
+    root->engine.onUncaughtError = [this](const juce::String &msg, const juce::String &trace) {
+        root.reset();
+        DBG(msg);
+        DBG(trace);
+    };
+
+    // Sanity check
+    root->evaluate(code);
+}
+} // namespace blueprint

--- a/blueprint/core/blueprint_HotReloader.h
+++ b/blueprint/core/blueprint_HotReloader.h
@@ -1,0 +1,43 @@
+/*
+  ==============================================================================
+
+    blueprint_HotRealoader.h
+    Created: 11 Dec 2019 2:20:29pm
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "blueprint_ReactApplicationRoot.h"
+
+namespace blueprint {
+//==============================================================================
+/** The BlueprintGenericEditor is a default AudioProcessorEditor with preinstalled functionality
+     *  for working with Blueprint.
+     *
+     *  It automatically manages a ReactApplicationRoot, registers some native methods
+     *  and properties for interfacing with the editor, and provides some helpful
+     *  development tools.
+     */
+    class HotReloader : public juce::Timer {
+    public:
+        HotReloader(std::unique_ptr<blueprint::ReactApplicationRoot> &appRoot, const juce::File &bundle,
+                    juce::Component &parentJuceComp);
+
+        ~HotReloader();
+
+        void timerCallback() override;
+
+    private:
+        //==============================================================================
+        /** Provisions and assigns a new ReactApplicationRoot. */
+        void assignNewAppRoot(const juce::String &codePath);
+
+        std::unique_ptr<blueprint::ReactApplicationRoot> &root;
+        juce::File bundleFile;
+
+        juce::Time lastModifiedTime;
+        juce::Component &parentComp;
+    };
+} // namespace blueprint


### PR DESCRIPTION
It's pretty much same code as you have in GenericEditor. I wasn't sure what is the best way to refresh UI so decided to pass reference to juce::Component. Let me know if you had something else on your mind.

I think whole HotReloader will need to be disabled for release target. But this PR doesn't have code which checks for it.