### PR TITLE
Fix gcc errors

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -47,6 +47,7 @@
 #include "blueprint.h"
 
 #include "yoga/yoga/log.cpp"
+#include "yoga/yoga/event/event.cpp"
 #include "yoga/yoga/Utils.cpp"
 #include "yoga/yoga/YGConfig.cpp"
 #include "yoga/yoga/YGEnums.cpp"

--- a/blueprint/blueprint.h
+++ b/blueprint/blueprint.h
@@ -41,6 +41,7 @@
 #endif
 
 #include "yoga/yoga/log.h"
+#include "yoga/yoga/event/event.h"
 #include "yoga/yoga/Utils.h"
 #include "yoga/yoga/YGConfig.h"
 #include "yoga/yoga/YGEnums.h"

--- a/blueprint/core/blueprint_EcmascriptEngine.cpp
+++ b/blueprint/core/blueprint_EcmascriptEngine.cpp
@@ -91,7 +91,7 @@ namespace blueprint
                     return false;
                 }
 
-                duk_throw(ctx);
+                 duk_throw_raw(ctx);
             }
 
             // Indicate success
@@ -218,7 +218,7 @@ namespace blueprint
                 return juce::var::undefined();
             }
 
-            duk_throw(ctx);
+            duk_throw_raw(ctx);
         }
 
         // Collect the return value

--- a/blueprint/core/blueprint_GenericEditor.cpp
+++ b/blueprint/core/blueprint_GenericEditor.cpp
@@ -84,7 +84,7 @@ namespace blueprint
         const juce::String stringValue = p->getText(newValue, 0);
 
         // Dispatch parameter value updates to the javascript engine at 30Hz
-        throttleMap.throttle(parameterIndex, 1000.0 / 30.0, [=]() {
+        throttleMap.throttle(parameterIndex, 1000.0 / 30.0, [=]() mutable {
             juce::MessageManager::callAsync([=]() mutable {
                 if (safeAppRoot)
                 {


### PR DESCRIPTION
@nick-thompson these changes fix some issues I had building on linux with GCC. It requires an update of yoga to fix an obscure enum-bitfield warning in GCC. We build with warnings as errors and this caused problems.

I've had these in my fork for a few weeks so have forgotten the exact errors but I can trigger said errors again if you'd like the compiler output. 