### PR TITLE
Initial refactor of hot reloading functionality.

### DIFF
--- a/blueprint/core/blueprint_GenericEditor.cpp
+++ b/blueprint/core/blueprint_GenericEditor.cpp
@@ -21,14 +21,14 @@ namespace blueprint
         for (auto& p : processor->getParameters())
             p->addListener(this);
 
-        // Now we can provision the app root
-        assignNewAppRoot(code);
+        // Setup the ReactApplicationRoot callbacks and evaluate the supplied JS code/bundle
+        registerAppRootCallbacks();
+        appRoot.evaluate(code);
 
-        // If an error showed up, our appRoot is already gone
-        if (appRoot)
-            addAndMakeVisible(appRoot.get());
+        // Add ReactApplicationRoot as child component
+        addAndMakeVisible(appRoot);
 
-        // Set an arbitrary size, should be overriden from outside the constructor
+        // Set an arbitrary size, should be overridden from outside the constructor
         setSize(400, 200);
     }
 
@@ -38,30 +38,24 @@ namespace blueprint
         // Sanity check
         jassert (bundle.existsAsFile());
         bundleFile = bundle;
-        lastModifiedTime = bundleFile.getLastModificationTime();
 
         // Bind parameter listeners
         for (auto& p : processor->getParameters())
             p->addListener(this);
 
-        // Now we can provision the app root
-        assignNewAppRoot(bundle.loadFileAsString());
+        // Setup the ReactApplicationRoot callbacks and evaluate the supplied JS code/bundle
+        registerAppRootCallbacks();
+        appRoot.evaluate(bundleFile);
 
-        // If an error showed up, our appRoot is already gone
-        if (appRoot)
-            addAndMakeVisible(appRoot.get());
+        // Add ReactApplicationRoot as child component
+        addAndMakeVisible(appRoot);
 
-        // Kick off the timer that polls for file changes
-        startTimer(50);
-
-        // Set an arbitrary size, should be overriden from outside the constructor
+        // Set an arbitrary size, should be overridden from outside the constructor
         setSize(400, 200);
     }
 
     BlueprintGenericEditor::~BlueprintGenericEditor()
     {
-        stopTimer();
-
         for (auto& p : processor.getParameters())
         {
             p->removeListener(this);
@@ -71,8 +65,6 @@ namespace blueprint
     //==============================================================================
     void BlueprintGenericEditor::parameterValueChanged (int parameterIndex, float newValue)
     {
-        Component::SafePointer<blueprint::ReactApplicationRoot> safeAppRoot (appRoot.get());
-
         // Collect some information about the parameter to push into the engine
         const auto& p = processor.getParameters()[parameterIndex];
         juce::String id = p->getName(100);
@@ -86,17 +78,14 @@ namespace blueprint
         // Dispatch parameter value updates to the javascript engine at 30Hz
         throttleMap.throttle(parameterIndex, 1000.0 / 30.0, [=]() mutable {
             juce::MessageManager::callAsync([=]() mutable {
-                if (safeAppRoot)
-                {
-                    safeAppRoot->dispatchEvent(
-                        "parameterValueChange",
-                        parameterIndex,
-                        id,
-                        defaultValue,
-                        newValue,
-                        stringValue
-                    );
-                }
+                appRoot.dispatchEvent(
+                    "parameterValueChange",
+                    parameterIndex,
+                    id,
+                    defaultValue,
+                    newValue,
+                    stringValue
+                );
             });
         });
     }
@@ -105,144 +94,96 @@ namespace blueprint
     {
         // We don't need to worry so much about throttling gesture events since they happen far
         // more slowly than value changes
-        if (appRoot)
-        {
-            appRoot->dispatchEvent("parameterGestureChange", parameterIndex, gestureIsStarting);
-        }
+        appRoot.dispatchEvent("parameterGestureChange", parameterIndex, gestureIsStarting);
     }
 
     //==============================================================================
-    void BlueprintGenericEditor::timerCallback()
-    {
-        auto lmt = bundleFile.getLastModificationTime();
-
-        if (lmt > lastModifiedTime)
-        {
-            // Sanity check... again
-            jassert (bundleFile.existsAsFile());
-
-            // Remove and delete the current appRoot
-            appRoot.reset();
-
-            // Then we assign a new one
-            assignNewAppRoot(bundleFile.loadFileAsString());
-
-            // Add and set size, carefull
-            if (appRoot)
-            {
-                addAndMakeVisible(appRoot.get());
-                appRoot->setBounds(getLocalBounds());
-            }
-
-            lastModifiedTime = lmt;
-        }
-    }
-
     void BlueprintGenericEditor::resized()
     {
-        // Evaluating the bundle in the app root might hit the error handler, which
-        // deletes the appRoot, in turn alerting the parent component (this) to remove
-        // its child and resize. So we're careful check the appRoot before doing anything
-        if (appRoot)
-        {
-            appRoot->setBounds(getLocalBounds());
-        }
+        // Ensure our ReactApplicationRoot always fills the entire bounds
+        // of this editor.
+        appRoot.setBounds(getLocalBounds());
     }
 
     void BlueprintGenericEditor::paint(juce::Graphics& g)
     {
         g.fillAll(juce::Colours::transparentWhite);
-
-        if (errorText)
-        {
-            g.fillAll(juce::Colour(0xffe14c37));
-            errorText->draw(g, getLocalBounds().toFloat().reduced(10.f));
-        }
     }
 
-    void BlueprintGenericEditor::assignNewAppRoot(const juce::String& code)
+    //==============================================================================
+    void BlueprintGenericEditor::beforeBundleEvaluated()
     {
-        // Assign a fresh appRoot
-        appRoot = std::make_unique<ReactApplicationRoot>();
-        appRoot->engine.onUncaughtError = [this](const juce::String& msg, const juce::String& trace) {
-            showError(trace);
-        };
-
         // If we have a valueTreeState, bind parameter methods to the new app root
         if (valueTreeState != nullptr)
         {
-            appRoot->engine.registerNativeMethod(
-                "beginParameterChangeGesture",
-                [](void* stash, const juce::var::NativeFunctionArgs& args) {
-                    auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
-                    const juce::String& paramId = args.arguments[0].toString();
+            appRoot.engine->registerNativeMethod(
+                    "beginParameterChangeGesture",
+                    [](void* stash, const juce::var::NativeFunctionArgs& args) {
+                        auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
+                        const juce::String& paramId = args.arguments[0].toString();
 
-                    if (auto* parameter = state->getParameter(paramId))
-                        parameter->beginChangeGesture();
+                        if (auto* parameter = state->getParameter(paramId))
+                            parameter->beginChangeGesture();
 
-                    return juce::var::undefined();
-                },
-                (void *) valueTreeState
+                        return juce::var::undefined();
+                    },
+                    (void *) valueTreeState
             );
 
-            appRoot->engine.registerNativeMethod(
-                "setParameterValueNotifyingHost",
-                [](void* stash, const juce::var::NativeFunctionArgs& args) {
-                    auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
-                    const juce::String& paramId = args.arguments[0].toString();
-                    const double value = args.arguments[1];
+            appRoot.engine->registerNativeMethod(
+                    "setParameterValueNotifyingHost",
+                    [](void* stash, const juce::var::NativeFunctionArgs& args) {
+                        auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
+                        const juce::String& paramId = args.arguments[0].toString();
+                        const double value = args.arguments[1];
 
-                    if (auto* parameter = state->getParameter(paramId))
-                        parameter->setValueNotifyingHost(value);
+                        if (auto* parameter = state->getParameter(paramId))
+                            parameter->setValueNotifyingHost(value);
 
-                    return juce::var::undefined();
-                },
-                (void *) valueTreeState
+                        return juce::var::undefined();
+                    },
+                    (void *) valueTreeState
             );
 
-            appRoot->engine.registerNativeMethod(
-                "endParameterChangeGesture",
-                [](void* stash, const juce::var::NativeFunctionArgs& args) {
-                    auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
-                    const juce::String& paramId = args.arguments[0].toString();
+            appRoot.engine->registerNativeMethod(
+                    "endParameterChangeGesture",
+                    [](void* stash, const juce::var::NativeFunctionArgs& args) {
+                        auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
+                        const juce::String& paramId = args.arguments[0].toString();
 
-                    if (auto* parameter = state->getParameter(paramId))
-                        parameter->endChangeGesture();
+                        if (auto* parameter = state->getParameter(paramId))
+                            parameter->endChangeGesture();
 
-                    return juce::var::undefined();
-                },
-                (void *) valueTreeState
+                        return juce::var::undefined();
+                    },
+                    (void *) valueTreeState
             );
         }
+    }
 
-        // Now evaluate the code within the environment. We reset the error text ahead
-        // of time, assuming the code will evaluate well
-        errorText.reset();
-        appRoot->evaluate(code);
-
-        // At this point the appRoot may have been removed due to an error evaluating
-        // the bundle, so we check for that case and halt if necessary
-        if (!appRoot)
-            return;
-
-        // By now, things look good, let's push current parameter values into
-        // the bundle
+    void BlueprintGenericEditor::afterBundleEvaluated()
+    {
+        // Push current parameter values into the bundle on load
         for (auto& p : processor.getParameters())
             parameterValueChanged(p->getParameterIndex(), p->getValue());
     }
 
-    void BlueprintGenericEditor::showError(const juce::String& trace)
+    void BlueprintGenericEditor::registerAppRootCallbacks()
     {
-        appRoot.reset();
-        errorText.reset(new juce::AttributedString(trace));
-#if JUCE_WINDOWS
-        errorText->setFont(juce::Font("Lucida Console", 18, juce::Font::FontStyleFlags::plain));
-#elif JUCE_MAC
-        errorText->setFont(juce::Font("Monaco", 18, juce::Font::FontStyleFlags::plain));
-#else
-        errorText->setFont(18);
-#endif
-        repaint();
-    }
+        appRoot.beforeBundleEval = [=] (std::optional<juce::File> bundle)
+        {
+            if (bundle && bundle->getFullPathName() == bundleFile.getFullPathName())
+            {
+                beforeBundleEvaluated();
+            }
+        };
 
+        appRoot.afterBundleEval = [=] (std::optional<juce::File> bundle)
+        {
+            if (bundle && bundle->getFullPathName() == bundleFile.getFullPathName())
+            {
+                afterBundleEvaluated();
+            }
+        };
+    }
 }

--- a/blueprint/core/blueprint_GenericEditor.h
+++ b/blueprint/core/blueprint_GenericEditor.h
@@ -26,8 +26,7 @@ namespace blueprint
      */
     class BlueprintGenericEditor
         : public juce::AudioProcessorEditor,
-          public juce::AudioProcessorParameter::Listener,
-          public juce::Timer
+          public juce::AudioProcessorParameter::Listener
     {
     public:
         //==============================================================================
@@ -42,31 +41,23 @@ namespace blueprint
         void parameterGestureChanged (int parameterIndex, bool gestureIsStarting) override;
 
         //==============================================================================
-        /** Implement the timer interface. */
-        void timerCallback() override;
-
         /** Override the component interface. */
         void resized() override;
         void paint (juce::Graphics&) override;
 
+        //==============================================================================
+
     private:
         //==============================================================================
-        /** Provisions and assigns a new ReactApplicationRoot. */
-        void assignNewAppRoot(const juce::String&);
-
-        /** Called for an uncaught error in the script engine.
-         *
-         *  Tears down an existing appRoot and paints the screen red with the
-         *  stack trace printed.
-         */
-        void showError(const juce::String& trace);
+        /** ReactApplicationRoot bundle eval callback functions */
+        void beforeBundleEvaluated();
+        void afterBundleEvaluated();
+        void registerAppRootCallbacks();
 
         //==============================================================================
-        std::unique_ptr<ReactApplicationRoot> appRoot;
-        std::unique_ptr<juce::AttributedString> errorText;
+        ReactApplicationRoot                  appRoot;
+        juce::File                            bundleFile;
         juce::AudioProcessorValueTreeState* valueTreeState;
-        juce::File bundleFile;
-        juce::Time lastModifiedTime;
 
         // For parameter updates to the script engine
         ThrottleMap throttleMap;

--- a/examples/BlueprintPlugin/Source/PluginEditor.cpp
+++ b/examples/BlueprintPlugin/Source/PluginEditor.cpp
@@ -20,7 +20,7 @@ BlueprintPluginAudioProcessorEditor::BlueprintPluginAudioProcessorEditor (Bluepr
     addAndMakeVisible(appRoot);
     appRoot.evaluate(sourceDir.getChildFile("ui/build/js/main.js").loadFileAsString());
     
-    appRoot.engine.registerNativeMethod(
+    appRoot.engine->registerNativeMethod(
         "setParameterValueNotifyingHost",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<BlueprintPluginAudioProcessorEditor*>(stash);
@@ -38,9 +38,7 @@ BlueprintPluginAudioProcessorEditor::BlueprintPluginAudioProcessorEditor (Bluepr
     
     
     // Globals in the js env
-    appRoot.engine.registerNativeProperty("__VERSION__", JucePlugin_VersionString);
-
-
+    appRoot.engine->registerNativeProperty("__VERSION__", JucePlugin_VersionString);
 
     setResizable(true, true);
     setResizeLimits(667, 375, 1334, 750);

--- a/examples/GainPlugin/Source/PluginEditor.cpp
+++ b/examples/GainPlugin/Source/PluginEditor.cpp
@@ -24,7 +24,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
     jassert (bundle.existsAsFile());
 
     // Bind some native callbacks
-    appRoot.engine.registerNativeMethod(
+    appRoot.engine->registerNativeMethod(
         "beginParameterChangeGesture",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<GainPluginAudioProcessorEditor*>(stash);
@@ -38,7 +38,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
         (void *) this
     );
 
-    appRoot.engine.registerNativeMethod(
+    appRoot.engine->registerNativeMethod(
         "setParameterValueNotifyingHost",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<GainPluginAudioProcessorEditor*>(stash);
@@ -53,7 +53,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
         (void *) this
     );
 
-    appRoot.engine.registerNativeMethod(
+    appRoot.engine->registerNativeMethod(
         "endParameterChangeGesture",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<GainPluginAudioProcessorEditor*>(stash);


### PR DESCRIPTION
@nick-thompson, here is some initial changes to move hot-reload into ReactApplicationRoot. 

Couple of questions. 

1. Do we need the evaluate(const juce::String& bundle) overload? I can see it could be useful to 
   evaluate inline JS code in things like unit tests etc but is there a strong need for this over using 
   juce::File ?

2. Should ReactApplicationRoot handle painting errors by default, only in debug or not at all? i.e. 
    should client code handle this? I think it's nice for ReactApplicationRoot to handle this.


Also worth mentioning, despite our original convo here: https://github.com/nick-thompson/blueprint/issues/27

I don't think it's actually useful  for us to have a before and after bundle eval callback. We just need after. This is because client code will no longer be tearing down the entire appRoot in the event of a reload/error. 

If you're happy with the overall shape of this I will refactor GenericEditor and the example apps to better demonstrate usage of the new shape. 

FYI I've tried to allow for multiple bundles as per our earlier conversation. I haven't tested this in earnest yet but will do so. I need to find some sensible polyfill to test with or something. Everything else appears to be working, hot-reload and error reporting/painting are both good.