### PR TITLE
For CanvasContext drawing operations use highest sampling quality

### DIFF
--- a/blueprint/core/blueprint_CanvasView.h
+++ b/blueprint/core/blueprint_CanvasView.h
@@ -101,6 +101,7 @@ namespace blueprint
         void init()
         {
             graphics = std::make_unique<juce::Graphics>(image);
+            graphics->setImageResamplingQuality(juce::Graphics::highResamplingQuality);
         }
 
     private:


### PR DESCRIPTION
@nick-thompson, I hit some issues with rendering quality. Given CanvasContext is responsible for drawing UI elements I think it makes sense for it's Graphics instance to use the highest image sampling quality possible.