### PR TITLE
Add initial support for canvas API drawImage() function.

### DIFF
--- a/blueprint/core/blueprint_CanvasView.h
+++ b/blueprint/core/blueprint_CanvasView.h
@@ -394,6 +394,45 @@ namespace blueprint
                         return juce::var();
                     }
             });
+
+            // drawImage support
+            setProperty("drawImage", juce::var::NativeFunction {
+                    [=](const juce::var::NativeFunctionArgs& args) -> juce::var {
+                        jassert(graphics);
+                        jassert(args.numArguments >= 3 && args.numArguments <= 5);
+
+                        const juce::String svg  = args.arguments[0].toString();
+                        const float        xPos = args.arguments[1];
+                        const float        yPos = args.arguments[2];
+
+                        //TODO: Add support for drawimage source width and source height to draw sub rect of an image.
+                        //      ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+
+                        std::unique_ptr<juce::XmlElement> svgElement  = juce::XmlDocument::parse(svg);
+                        jassert(svgElement);
+
+                        if (svgElement)
+                        {
+                            std::unique_ptr<juce::Drawable> svgDrawable = juce::Drawable::createFromSVG(*svgElement);
+
+                            if (args.numArguments == 5)
+                            {
+                                const float destWidth  = args.arguments[3];
+                                const float destHeight = args.arguments[4];
+                                const auto  bounds     = juce::Rectangle<float>(xPos, yPos, destWidth, destHeight);
+
+                                svgDrawable->setTransformToFit(bounds, juce::RectanglePlacement::stretchToFit);
+                                svgDrawable->draw(*graphics, 1.0f);
+                            }
+                            else
+                            {
+                                svgDrawable->drawAt(*graphics, xPos, yPos, 1.0);
+                            }
+                        }
+
+                        return juce::var();
+                    }
+            });
         }
 
         //==============================================================================

--- a/blueprint/core/blueprint_CanvasView.h
+++ b/blueprint/core/blueprint_CanvasView.h
@@ -408,26 +408,28 @@ namespace blueprint
                         //TODO: Add support for drawimage source width and source height to draw sub rect of an image.
                         //      ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 
-                        std::unique_ptr<juce::XmlElement> svgElement  = juce::XmlDocument::parse(svg);
-                        jassert(svgElement);
+                        std::unique_ptr<juce::XmlElement> svgElement = juce::XmlDocument::parse(svg);
 
-                        if (svgElement)
+                        if (!svgElement)
                         {
-                            std::unique_ptr<juce::Drawable> svgDrawable = juce::Drawable::createFromSVG(*svgElement);
+                            DBG("\"WARNING: Invalid SVG string supplied to `drawImage`.\"");
+                            return juce::var();
+                        }
 
-                            if (args.numArguments == 5)
-                            {
-                                const float destWidth  = args.arguments[3];
-                                const float destHeight = args.arguments[4];
-                                const auto  bounds     = juce::Rectangle<float>(xPos, yPos, destWidth, destHeight);
+                        std::unique_ptr<juce::Drawable> svgDrawable = juce::Drawable::createFromSVG(*svgElement);
 
-                                svgDrawable->setTransformToFit(bounds, juce::RectanglePlacement::stretchToFit);
-                                svgDrawable->draw(*graphics, 1.0f);
-                            }
-                            else
-                            {
-                                svgDrawable->drawAt(*graphics, xPos, yPos, 1.0);
-                            }
+                        if (args.numArguments == 5)
+                        {
+                            const float destWidth  = args.arguments[3];
+                            const float destHeight = args.arguments[4];
+                            const auto  bounds     = juce::Rectangle<float>(xPos, yPos, destWidth, destHeight);
+
+                            svgDrawable->setTransformToFit(bounds, juce::RectanglePlacement::stretchToFit);
+                            svgDrawable->draw(*graphics, 1.0f);
+                        }
+                        else
+                        {
+                            svgDrawable->drawAt(*graphics, xPos, yPos, 1.0);
                         }
 
                         return juce::var();


### PR DESCRIPTION
  This implementation of the CanvasRenderingContext2D.drawImage()
  function currently just supports svg strings which can be loaded via
  require() and the webpack svg-inline-loader.


@nick-thompson, 

To get this to work properly for my specific use case I actually needed to interrogate the SVG string to get the image/viewBox width and height. A function like this (slightly less hacky) may or may not be of use in Blueprint.

```
function getSvgDimensions(svg) {
    let parseString = require('xml2js').parseString;
    let svgDimensions = {};

    parseString(svg, (err, result) => {
        if (result) {
            const viewBox = result.svg.$.viewBox;
            if (viewBox) {
                const dimensions = viewBox.split(' ');
                const width  = parseInt(dimensions[2]);
                const height = parseInt(dimensions[3]);

                svgDimensions = { width, height };
            }
        }
        else {
            console.log('Bad SVG string passed: ' + err);
        }
    });

    return svgDimensions;
}
```