### PR TITLE
Add initial support for canvas API text functions.

### DIFF
--- a/packages/juce-blueprint/esm/Blueprint.js
+++ b/packages/juce-blueprint/esm/Blueprint.js
@@ -55,6 +55,28 @@ export function bindCanvasContextProperties(ctx) {
       this.__setLineWidth(value);
     }
   });
+
+  Object.defineProperty(ctx, 'font', {
+    enumerable: false,
+    configurable: false,
+    get: function() {
+      return 'Not Supported';
+    },
+    set: function(value) {
+      this.__setFont(value);
+    }
+  });
+
+  Object.defineProperty(ctx, 'textAlign', {
+    enumerable: false,
+    configurable: false,
+    get: function() {
+      return 'Not Supported';
+    },
+    set: function(value) {
+      this.__setTextAlign(value);
+    }
+  });
 }
 
 export class Canvas extends Component {


### PR DESCRIPTION
  This change adds the following CanvasRenderingContext2D text functions
  and properties:

  . fillText()
  . strokeText()
  . font
  . textAlign

@nick-thompson this all works pretty well for me. Ideally it should be merged after the fixes in https://github.com/nick-thompson/blueprint/pull/56.  I think once this and the drawImage support are in I'll hold of implementing anymore of the CanvasRenderingContext2D API and work on documentation and a little <Canvas> example juce app. 