### PR TITLE
Fixup a hot reload error in ReactApplicationRoot.

### DIFF
--- a/blueprint/core/blueprint_ReactApplicationRoot.h
+++ b/blueprint/core/blueprint_ReactApplicationRoot.h
@@ -52,6 +52,16 @@ namespace blueprint
             watchedBundles.push_back({ bundle, bundle.getLastModificationTime() });
         }
 
+        bool watching(const juce::File &bundle) const
+        {
+            return std::find_if(  watchedBundles.cbegin()
+                                , watchedBundles.cend()
+                                , [=](const WatchedBundle& wb)
+                                  {
+                                      return wb.bundle.getFullPathName() == bundle.getFullPathName();
+                                  }) != watchedBundles.cend();
+        }
+
     private:
         void timerCallback() override
         {
@@ -175,7 +185,9 @@ namespace blueprint
             if (hotReloadEnabled)
             {
                 jassert(bundleWatcher);
-                bundleWatcher->watch(bundle);
+
+                if (!bundleWatcher->watching(bundle))
+                    bundleWatcher->watch(bundle);
             }
 
             return result;
@@ -364,7 +376,7 @@ namespace blueprint
             initEngine();
             initViewManager();
 
-            evaluate(bundle.loadFileAsString());
+            evaluate(bundle);
         }
 
         //==============================================================================


### PR DESCRIPTION
  Ensure we call then juce::File overload of evaluate when bundle
  has changed and avoid duplicate watchers.

@nick-thompson, realised there is an error in this bit of hot reload code. Could have used an unordered_map or something to avoid duplicates but I think this is nicer to be honest as the timerCallback is going to be called more often and iterating over a map with pairs is uglier imho. 