### PR TITLE
Initial spike for duktape debugger support. Currently a work in

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -43,6 +43,7 @@
 
 #include "duktape/src-noline/duktape.c"
 #include "duktape/extras/console/duk_console.c"
+#include "duktape/examples/debug-trans-socket/duk_trans_socket_unix.c"
 
 #include "blueprint.h"
 

--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -31,6 +31,15 @@
 #define DUK_USE_DATE_NOW_WINDOWS 1
 #endif
 
+/*
+ * For whatever reason it is necessary to define this to resolve errors caused by both
+ * duktape and juce including parts of the winsock2 API. There may be a better way to
+ * resolve this.
+ */
+#if defined (_WIN32) || defined (_WIN64)
+#define _WINSOCKAPI_
+#endif
+
 // Disable compiler warnings for external source files (duktape & yoga)
 #if _MSC_VER
   #pragma warning(push)
@@ -41,11 +50,22 @@
   #pragma warning(disable : 4702) // unreachable code
 #endif
 
-#include <juce_core/juce_core.h>
+
+// We rely on the JUCE_DEBUG macro in duk_config.h at the moment to determine
+// when we enable duktape debug features. This is a bit of a hack to make this
+// work. We should be able to do better and may do so once we enable custom duktape
+// configs.
+#include <juce_core/system/juce_TargetPlatform.h>
 
 #include "duktape/src-noline/duktape.c"
 #include "duktape/extras/console/duk_console.c"
-#include "duktape/examples/debug-trans-socket/duk_trans_socket_unix.c"
+
+#if defined (_WIN32) || defined (_WIN64)
+    #include "duktape/examples/debug-trans-socket/duk_trans_socket_windows.c"
+#else
+    #include "duktape/examples/debug-trans-socket/duk_trans_socket_unix.c"
+#endif
+
 
 #include "blueprint.h"
 

--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -41,6 +41,8 @@
   #pragma warning(disable : 4702) // unreachable code
 #endif
 
+#include <juce_core/juce_core.h>
+
 #include "duktape/src-noline/duktape.c"
 #include "duktape/extras/console/duk_console.c"
 #include "duktape/examples/debug-trans-socket/duk_trans_socket_unix.c"

--- a/blueprint/blueprint.h
+++ b/blueprint/blueprint.h
@@ -56,6 +56,7 @@
 
 #include "duktape/src-noline/duktape.h"
 #include "duktape/extras/console/duk_console.h"
+#include "duktape/examples/debug-trans-socket/duk_trans_socket.h"
 
 #include "core/blueprint_EcmascriptEngine.h"
 #include "core/blueprint_CanvasView.h"

--- a/blueprint/core/blueprint_CanvasView.h
+++ b/blueprint/core/blueprint_CanvasView.h
@@ -527,7 +527,7 @@ namespace blueprint
                         //TODO: Add support for drawimage source width and source height to draw sub rect of an image.
                         //      ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 
-                        std::unique_ptr<juce::XmlElement> svgElement = juce::XmlDocument::parse(svg);
+                        std::unique_ptr<juce::XmlElement> svgElement(juce::XmlDocument::parse(svg));
 
                         if (!svgElement)
                         {
@@ -535,7 +535,7 @@ namespace blueprint
                             return juce::var();
                         }
 
-                        std::unique_ptr<juce::Drawable> svgDrawable = juce::Drawable::createFromSVG(*svgElement);
+                        std::unique_ptr<juce::Drawable> svgDrawable(juce::Drawable::createFromSVG(*svgElement));
 
                         if (args.numArguments == 5)
                         {

--- a/blueprint/core/blueprint_EcmascriptEngine.cpp
+++ b/blueprint/core/blueprint_EcmascriptEngine.cpp
@@ -74,6 +74,10 @@ namespace blueprint
             throw std::runtime_error(msg);
         }
 
+        //TODO: Keep safeEvalString and safeCompileFile or make EcmascripEngine member funcs
+        //      now that we have out errorHandle wrapper in EcmascriptEngine? Passing
+        //      callback here feels a bit ambiguous in regards to popping the error
+        //      off of the stack after invoking the error callback. Whose responsibility is it etc.
         template <typename T>
         static bool safeEvalString(duk_context* ctx, const juce::String& s, T&& callback)
         {
@@ -81,13 +85,8 @@ namespace blueprint
             {
                 if (callback != nullptr)
                 {
-                    const juce::String trace = duk_safe_to_stacktrace(ctx, -1);
-                    const juce::String msg = duk_safe_to_string(ctx, -1);
-
-                    // Call the user provided error handler
-                    std::invoke(callback, msg, trace);
-
-                    // Indicate failure
+                    // Call the user provided error handler and indicate failure
+                    std::invoke(callback);
                     return false;
                 }
 
@@ -108,13 +107,8 @@ namespace blueprint
             {
                 if (callback != nullptr)
                 {
-                    const juce::String trace = duk_safe_to_stacktrace(ctx, -1);
-                    const juce::String msg = duk_safe_to_string(ctx, -1);
-
-                    // Call the user provided error handler.js
-                    std::invoke(callback, msg, trace);
-
-                    // Indicate failure
+                    // Call the user provided error handler.js and indicate failure
+                    std::invoke(callback);
                     return false;
                 }
 
@@ -123,6 +117,13 @@ namespace blueprint
 
             // Indicate success
             return true;
+       }
+
+       static void dumpContext(duk_context* ctx)
+       {
+           duk_push_context_dump(ctx);
+           DBG(duk_to_string(ctx, -1));
+           duk_pop(ctx);
        }
     }
 
@@ -134,6 +135,30 @@ namespace blueprint
 
         // Add console.log support
         duk_console_init(ctx, DUK_CONSOLE_FLUSH);
+
+        // Create our error handler wrapping a user supplied error callback.
+        errorHandler = [=]
+        {
+            if (onUncaughtError == nullptr)
+                duk_throw_raw(ctx);
+
+            const juce::String trace = duk_safe_to_stacktrace(ctx, -1);
+            const juce::String msg = duk_safe_to_string(ctx, -1);
+
+            // Call the user provided error handler
+            std::invoke(onUncaughtError, msg, trace);
+
+            // Clear out the stack so we can re-register native functions
+            // after we clear out the lambda release pool etc.
+            while (duk_get_top(ctx))
+            {
+                duk_remove(ctx, duk_get_top_index(ctx));
+            }
+
+            // Clear the LambdaHelper release pool as duktape does not call object
+            // finalizers in the event of an evaluation error or duk_pcall failure.
+            lambdaReleasePool.clear();
+        };
     }
 
     EcmascriptEngine::~EcmascriptEngine()
@@ -144,37 +169,32 @@ namespace blueprint
     //==============================================================================
     juce::var EcmascriptEngine::evaluate (const juce::String& code)
     {
-        if (!detail::safeEvalString(ctx, code, onUncaughtError))
-            return juce::var::undefined();
+        jassert(code.isNotEmpty());
+
+        if (!detail::safeEvalString(ctx, code, errorHandler))
+            return juce::var(EvaluationError);
 
         auto result = readVarFromDukStack(ctx, -1);
-
         duk_pop(ctx);
+
         return result;
     }
 
     juce::var EcmascriptEngine::evaluate (const juce::File& code)
     {
+        jassert(code.existsAsFile());
+        jassert(code.loadFileAsString().isNotEmpty());
+
         juce::var result = juce::var::undefined();
 
-        if (detail::safeCompileFile(ctx, code, onUncaughtError))
+        if (!detail::safeCompileFile(ctx, code, errorHandler))
+            return juce::var(EvaluationError);
+
+        // Call compiled function
+        if (duk_pcall(ctx, 0) != DUK_EXEC_SUCCESS)
         {
-            // Call compiled function
-            if (duk_pcall(ctx, 0) != DUK_EXEC_SUCCESS)
-            {
-                if (onUncaughtError != nullptr)
-                {
-                    const juce::String trace = duk_safe_to_stacktrace(ctx, -1);
-                    const juce::String msg = duk_safe_to_string(ctx, -1);
-
-                    // Call the user provided error handler
-                    std::invoke(onUncaughtError, msg, trace);
-
-                    return juce::var::undefined();
-                }
-
-                duk_throw_raw(ctx);
-            }
+            errorHandler();
+            return juce::var(EvaluationError);
         }
 
         // Collect the return value
@@ -208,7 +228,7 @@ namespace blueprint
     void EcmascriptEngine::registerNativeMethod (const juce::String& target, const juce::String& name, NativeFunction fn, void* stash)
     {
         // Evaluate the target string on the context, leaving the result on the stack
-        if (!detail::safeEvalString(ctx, target, onUncaughtError))
+        if (!detail::safeEvalString(ctx, target, errorHandler))
             return;
 
         // We wrap the native function to provide a helper layer storing and retrieving the
@@ -238,7 +258,8 @@ namespace blueprint
     void EcmascriptEngine::registerNativeProperty (const juce::String& target, const juce::String& name, const juce::var& value)
     {
         // Evaluate the target string on the context, leaving the result on the stack
-        if (!detail::safeEvalString(ctx, target, onUncaughtError))
+        // TODO: Return specific error code if target not in stack?
+        if (!detail::safeEvalString(ctx, target, errorHandler))
             return;
 
         // Then assign the property
@@ -250,13 +271,15 @@ namespace blueprint
     juce::var EcmascriptEngine::invoke (const juce::String& name, const std::vector<juce::var>& vargs)
     {
         // Evaluate the target string on the context, leaving the result on the stack
-        if (!detail::safeEvalString(ctx, name, onUncaughtError))
+        // TODO: Return specific error code if name not in stack?
+        if (!detail::safeEvalString(ctx, name, errorHandler))
             return juce::var::undefined();
 
+        // Ensure requested function exists on the stack
         duk_require_function(ctx, -1);
 
         // Push the args to the duktape stack
-        auto nargs = static_cast<duk_idx_t>(vargs.size());
+        const auto nargs = static_cast<duk_idx_t>(vargs.size());
         duk_require_stack_top(ctx, nargs);
 
         for (auto& p : vargs)
@@ -265,24 +288,16 @@ namespace blueprint
         // Invocation
         if (duk_pcall(ctx, nargs) != DUK_EXEC_SUCCESS)
         {
-            if (onUncaughtError != nullptr)
-            {
-                const juce::String trace = duk_safe_to_stacktrace(ctx, -1);
-                const juce::String msg = duk_safe_to_string(ctx, -1);
+            errorHandler();
 
-                // Call the user provided error handler
-                std::invoke(onUncaughtError, msg, trace);
-
-                return juce::var::undefined();
-            }
-
-            duk_throw_raw(ctx);
+            // TODO: Return specific error code if invoke fails?
+            return juce::var::undefined();
         }
 
         // Collect the return value
         auto result = readVarFromDukStack(ctx, -1);
-
         duk_pop(ctx);
+
         return result;
     }
 
@@ -522,6 +537,7 @@ namespace blueprint
                             // the global stash and invoke it with the provided args.
                             duk_push_global_stash(ctx);
                             duk_get_prop_string(ctx, -1, funId.toRawUTF8());
+
                             duk_require_function(ctx, -1);
 
                             // Push the args to the duktape stack

--- a/blueprint/core/blueprint_EcmascriptEngine.cpp
+++ b/blueprint/core/blueprint_EcmascriptEngine.cpp
@@ -552,7 +552,6 @@ namespace blueprint
                             // the global stash and invoke it with the provided args.
                             duk_push_global_stash(ctx);
                             duk_get_prop_string(ctx, -1, funId.toRawUTF8());
-
                             duk_require_function(ctx, -1);
 
                             // Push the args to the duktape stack

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -34,9 +34,8 @@ namespace blueprint
         static constexpr auto EvaluationError = "EcmascriptEngineEvaluationError";
 
         /** Evaluates the given code in the interpreter, returning the result.
-         *  In the event of an evaluation error (often do to a javascript error)
-         *  evaluate will call the user supplied error handler and return an
-         *  EvaluationError result.
+         *  In the event of an evaluation error, evaluate will call the user
+         *  supplied error handler and return an EvaluationError result.
          *  @see onUncaughtError.
          */
         juce::var evaluate (const juce::String& code);

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -18,7 +18,7 @@ namespace blueprint
      *  with an interface implemented by Duktape, but which may be implemented by one of
      *  many embedded engines in the future.
      */
-    class EcmascriptEngine
+    class EcmascriptEngine : private juce::Timer
     {
     public:
         //==============================================================================
@@ -138,6 +138,9 @@ namespace blueprint
         juce::var readVarFromDukStack (duk_context* ctx, duk_idx_t idx);
 
     private:
+        //==============================================================================
+        void timerCallback() override;
+
         //==============================================================================
         // Wraps the user provided error handler and is responsible for cleaning up
         // the EcmascriptEngine in the event of an evaluation error.

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -30,7 +30,15 @@ namespace blueprint
         ~EcmascriptEngine();
 
         //==============================================================================
-        /** Evaluates the given code in the interpreter, returning the result. */
+        /** Constant representing an evaluation error */
+        static constexpr auto EvaluationError = "EcmascriptEngineEvaluationError";
+
+        /** Evaluates the given code in the interpreter, returning the result.
+         *  In the event of an evaluation error (often do to a javascript error)
+         *  evaluate will call the user supplied error handler and return an
+         *  EvaluationError result.
+         *  @see onUncaughtError.
+         */
         juce::var evaluate (const juce::String& code);
         juce::var evaluate (const juce::File& code);
 
@@ -106,7 +114,7 @@ namespace blueprint
          * It is possible to continue using this EcmascriptEngine instance after such an error has been
          * raised. For example callers may wish to handle such an error and subsequently reload a modified
          * version of a JS bundle file as part of a "hot-reload" workflow, incrementally fixing/debugging
-         * errors.
+         * errors. ReactApplicationRoot provides such a workflow.
          */
         std::function<void(const juce::String& msg, const juce::String& trace)> onUncaughtError;
 
@@ -130,6 +138,11 @@ namespace blueprint
         juce::var readVarFromDukStack (duk_context* ctx, duk_idx_t idx);
 
     private:
+        //==============================================================================
+        // Wraps the user provided error handler and is responsible for cleaning up
+        // the EcmascriptEngine in the event of an evaluation error.
+        std::function<void()> errorHandler;
+
         //==============================================================================
         struct LambdaHelper {
             LambdaHelper(juce::var::NativeFunction fn);

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -32,6 +32,7 @@ namespace blueprint
         //==============================================================================
         /** Evaluates the given code in the interpreter, returning the result. */
         juce::var evaluate (const juce::String& code);
+        juce::var evaluate (const juce::File& code);
 
         //==============================================================================
         /** Registers a native method by the given name in the global namespace. */
@@ -99,14 +100,26 @@ namespace blueprint
         juce::var invoke (const juce::String& name, T... args);
 
         //==============================================================================
-        /** A public member which can be assigned a callback for delegating fatal error
-         *  handling to user code.
+        /** A public member which can be assigned a callback for delegating error handling to user code.
          *
-         *  Upon returning, your callback should have ceased further execution of code
-         *  in this EcmascriptEngine. You will need to create and initialize a new one
-         *  to proceed safely.
+         * This callback will be called primarily in the case of recoverable errors when evaluating JS code.
+         * It is possible to continue using this EcmascriptEngine instance after such an error has been
+         * raised. For example callers may wish to handle such an error and subsequently reload a modified
+         * version of a JS bundle file as part of a "hot-reload" workflow, incrementally fixing/debugging
+         * errors.
          */
         std::function<void(const juce::String& msg, const juce::String& trace)> onUncaughtError;
+
+        //==============================================================================
+        /**
+         * Pauses execution and waits for a debug client to attach and begin a debug session.
+         */
+        void debuggerAttach();
+
+        /**
+         * Detaches the from the current debug session/attachment.
+         */
+        void debuggerDetach();
 
         //==============================================================================
         // TODO: These pushVarToDukStack/readVarFromDukStack should be private, but are

--- a/blueprint/core/blueprint_GenericEditor.cpp
+++ b/blueprint/core/blueprint_GenericEditor.cpp
@@ -116,7 +116,7 @@ namespace blueprint
         // If we have a valueTreeState, bind parameter methods to the new app root
         if (valueTreeState != nullptr)
         {
-            appRoot.engine->registerNativeMethod(
+            appRoot.engine.registerNativeMethod(
                     "beginParameterChangeGesture",
                     [](void* stash, const juce::var::NativeFunctionArgs& args) {
                         auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
@@ -130,7 +130,7 @@ namespace blueprint
                     (void *) valueTreeState
             );
 
-            appRoot.engine->registerNativeMethod(
+            appRoot.engine.registerNativeMethod(
                     "setParameterValueNotifyingHost",
                     [](void* stash, const juce::var::NativeFunctionArgs& args) {
                         auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
@@ -145,7 +145,7 @@ namespace blueprint
                     (void *) valueTreeState
             );
 
-            appRoot.engine->registerNativeMethod(
+            appRoot.engine.registerNativeMethod(
                     "endParameterChangeGesture",
                     [](void* stash, const juce::var::NativeFunctionArgs& args) {
                         auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);

--- a/blueprint/core/blueprint_GenericEditor.cpp
+++ b/blueprint/core/blueprint_GenericEditor.cpp
@@ -14,24 +14,6 @@ namespace blueprint
 {
 
     //==============================================================================
-    BlueprintGenericEditor::BlueprintGenericEditor (juce::AudioProcessor* processor, const juce::String& code, juce::AudioProcessorValueTreeState* vts)
-        : juce::AudioProcessorEditor(processor), valueTreeState(vts)
-    {
-        // Bind parameter listeners
-        for (auto& p : processor->getParameters())
-            p->addListener(this);
-
-        // Setup the ReactApplicationRoot callbacks and evaluate the supplied JS code/bundle
-        registerAppRootCallbacks();
-        appRoot.evaluate(code);
-
-        // Add ReactApplicationRoot as child component
-        addAndMakeVisible(appRoot);
-
-        // Set an arbitrary size, should be overridden from outside the constructor
-        setSize(400, 200);
-    }
-
     BlueprintGenericEditor::BlueprintGenericEditor (juce::AudioProcessor* processor, const juce::File& bundle, juce::AudioProcessorValueTreeState* vts)
         : juce::AudioProcessorEditor(processor), valueTreeState(vts)
     {
@@ -170,17 +152,17 @@ namespace blueprint
 
     void BlueprintGenericEditor::registerAppRootCallbacks()
     {
-        appRoot.beforeBundleEval = [=] (std::optional<juce::File> bundle)
+        appRoot.beforeBundleEval = [=] (const juce::File& bundle)
         {
-            if (bundle && bundle->getFullPathName() == bundleFile.getFullPathName())
+            if (bundle.getFullPathName() == bundleFile.getFullPathName())
             {
                 beforeBundleEvaluated();
             }
         };
 
-        appRoot.afterBundleEval = [=] (std::optional<juce::File> bundle)
+        appRoot.afterBundleEval = [=] (const juce::File& bundle)
         {
-            if (bundle && bundle->getFullPathName() == bundleFile.getFullPathName())
+            if (bundle.getFullPathName() == bundleFile.getFullPathName())
             {
                 afterBundleEvaluated();
             }

--- a/blueprint/core/blueprint_GenericEditor.h
+++ b/blueprint/core/blueprint_GenericEditor.h
@@ -30,7 +30,6 @@ namespace blueprint
     {
     public:
         //==============================================================================
-        BlueprintGenericEditor (juce::AudioProcessor*, const juce::String&, juce::AudioProcessorValueTreeState* = nullptr);
         BlueprintGenericEditor (juce::AudioProcessor*, const juce::File&, juce::AudioProcessorValueTreeState* = nullptr);
 
         ~BlueprintGenericEditor();

--- a/blueprint/core/blueprint_ReactApplicationRoot.h
+++ b/blueprint/core/blueprint_ReactApplicationRoot.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <map>
+#include <optional>
 
 #include "blueprint_CanvasView.h"
 #include "blueprint_EcmascriptEngine.h"
@@ -242,7 +242,7 @@ namespace blueprint
         {
             JUCE_ASSERT_MESSAGE_THREAD
             jassert(engine);
-            
+
             // engine may have been reset in the event of a bundle eval error. We don't want to
             // crash if client code tries to immediately dispatch an event after bundle loading.
             // ReactApplicationRoot should report a generic error to the user rather than crashing.
@@ -256,7 +256,7 @@ namespace blueprint
         {
             JUCE_ASSERT_MESSAGE_THREAD
             jassert(engine);
-            
+
             // engine may have been reset in the event of a bundle eval error. We don't want to
             // crash if client code tries to immediately dispatch an event after bundle loading.
             // ReactApplicationRoot should report a generic error to the user rather than crashing.
@@ -514,7 +514,7 @@ namespace blueprint
         void registerNativeRenderingHooks()
         {
             jassert(engine);
-            
+
             engine->registerNativeProperty("__BlueprintNative__", juce::JSON::parse("{}"));
 
             engine->registerNativeMethod("__BlueprintNative__", "createViewInstance", [](void* stash, const juce::var::NativeFunctionArgs& args) {

--- a/blueprint/duktape/examples/debug-trans-socket/duk_trans_socket_unix.c
+++ b/blueprint/duktape/examples/debug-trans-socket/duk_trans_socket_unix.c
@@ -241,7 +241,15 @@ duk_size_t duk_trans_socket_write_cb(void *udata, const char *buffer, duk_size_t
 	 * timeout here to recover from "black hole" disconnects.
 	 */
 
+	//TODO: Hacked the example implementation for now to avoid SIGPIPE errors terminating the
+	//      program when debug client terminates the tcp connection.
+	//      We should probably move this to a blueprint specific debug transport implementation at some point.
+	//      For more advanced users, it may be useful to allow a mechanism to easily override the
+	//      transport mechanism used for debugging. i.e. to allow debug over serial etc.
+	signal(SIGPIPE, SIG_IGN);
 	ret = write(client_sock, (const void *) buffer, (size_t) length);
+    signal(SIGPIPE, SIG_DFL);
+
 	if (ret <= 0 || ret > (ssize_t) length) {
 		fprintf(stderr, "%s: debug write failed, closing connection: %s\n",
 		        __FILE__, strerror(errno));

--- a/blueprint/duktape/src-noline/duk_config.h
+++ b/blueprint/duktape/src-noline/duk_config.h
@@ -3739,4 +3739,15 @@ typedef struct duk_hthread duk_context;
 #error unsupported: byte order detection failed
 #endif  /* defined(DUK_USE_BYTEORDER) */
 
+
+#if JUCE_DEBUG
+//TODO: We need a better system for allowing custom/user configured duk_config headers
+//      in blueprint. This set of inline change works for now to enable debugging support.
+#define DUK_USE_INTERRUPT_COUNTER
+#define DUK_USE_DEBUGGER_SUPPORT
+#define DUK_USE_DEBUGGER_INSPECT
+#define DUK_USE_DEBUGGER_FWD_LOGGING
+
+#endif
+
 #endif  /* DUK_CONFIG_H_INCLUDED */

--- a/examples/GainPlugin/Source/PluginEditor.cpp
+++ b/examples/GainPlugin/Source/PluginEditor.cpp
@@ -69,7 +69,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
 
     // Next we just add our appRoot and kick off the app bundle.
     addAndMakeVisible(appRoot);
-    appRoot.evaluate(bundle.loadFileAsString());
+    appRoot.evaluate(bundle);
 
     // Now our React application is up and running, so we can start dispatching
     // events, such as current parameter values.

--- a/examples/GainPlugin/Source/PluginEditor.cpp
+++ b/examples/GainPlugin/Source/PluginEditor.cpp
@@ -24,7 +24,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
     jassert (bundle.existsAsFile());
 
     // Bind some native callbacks
-    appRoot.engine->registerNativeMethod(
+    appRoot.engine.registerNativeMethod(
         "beginParameterChangeGesture",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<GainPluginAudioProcessorEditor*>(stash);
@@ -38,7 +38,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
         (void *) this
     );
 
-    appRoot.engine->registerNativeMethod(
+    appRoot.engine.registerNativeMethod(
         "setParameterValueNotifyingHost",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<GainPluginAudioProcessorEditor*>(stash);
@@ -53,7 +53,7 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
         (void *) this
     );
 
-    appRoot.engine->registerNativeMethod(
+    appRoot.engine.registerNativeMethod(
         "endParameterChangeGesture",
         [](void* stash, const juce::var::NativeFunctionArgs& args) {
             auto* self = reinterpret_cast<GainPluginAudioProcessorEditor*>(stash);

--- a/examples/GainPlugin/Source/jsui/webpack.config.js
+++ b/examples/GainPlugin/Source/jsui/webpack.config.js
@@ -2,8 +2,11 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: __dirname + '/build/js',
-    filename: 'main.js'
+    filename: 'main.js',
+    sourceMapFilename: "[file].map",
+    devtoolModuleFilenameTemplate: 'webpack:///[absolute-resource-path]'
   },
+  devtool: "source-map",
   module: {
     rules: [
       {

--- a/examples/GainPlugin/Source/jsui/webpack.config.js
+++ b/examples/GainPlugin/Source/jsui/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
     path: __dirname + '/build/js',
     filename: 'main.js',
     sourceMapFilename: "[file].map",
-    devtoolModuleFilenameTemplate: 'webpack:///[absolute-resource-path]'
+     devtoolModuleFilenameTemplate: info =>
+    `webpack:///${info.absoluteResourcePath.replace(/\\/g, '/')}`
   },
   devtool: "source-map",
   module: {

--- a/packages/juce-blueprint/template/webpack.config.js
+++ b/packages/juce-blueprint/template/webpack.config.js
@@ -2,8 +2,11 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: __dirname + '/build/js',
-    filename: 'main.js'
+    filename: 'main.js',
+    sourceMapFilename: "[file].map",
+    devtoolModuleFilenameTemplate: 'webpack:///[absolute-resource-path]'
   },
+  devtool: "source-map",
   module: {
     rules: [
       {

--- a/packages/juce-blueprint/template/webpack.config.js
+++ b/packages/juce-blueprint/template/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
     path: __dirname + '/build/js',
     filename: 'main.js',
     sourceMapFilename: "[file].map",
-    devtoolModuleFilenameTemplate: 'webpack:///[absolute-resource-path]'
+     devtoolModuleFilenameTemplate: info =>
+    `webpack:///${info.absoluteResourcePath.replace(/\\/g, '/')}`
   },
   devtool: "source-map",
   module: {


### PR DESCRIPTION
progress.

@nick-thompson, this is still in progress but thought I'd open up the PR so we can begin to discuss. I'll follow up with a comment on the PR explaining the current setup/workflow with the vscode extension using source maps. 

Without source-maps it should still be possible to debug the main.js/bundle file in the duktape browser debugger I believe. Would need to switch off minification in webpack when building bundles to make this usable. I will test this shortly. 

I've only been testing on Linux in the context of my app thus far so I'm about the pull this branch down on the mac and test with the example GainPlugin. 

I need to make a PR to the vscode extension as I have had to fix/hack one thing to get this all working. I'll fork the extension and drop you a link over so you can play with it. 

Note that I've had to edit duk_config.h as the debug defines need to be toggled at that level rather than in blueprint.cpp. This may prompt discussions about the build system and custom duktape headers but perhaps we can get away with this change to the default config for now?