### PR TITLE
Update the GainPlugin example parameter throttling

### DIFF
--- a/examples/GainPlugin/Source/PluginEditor.cpp
+++ b/examples/GainPlugin/Source/PluginEditor.cpp
@@ -71,15 +71,25 @@ GainPluginAudioProcessorEditor::GainPluginAudioProcessorEditor (GainPluginAudioP
     addAndMakeVisible(appRoot);
     appRoot.evaluate(bundle);
 
-    // Now our React application is up and running, so we can start dispatching
-    // events, such as current parameter values.
-    for (auto& p : processor.getParameters())
+    // Now we set up parameter listeners and register their current values.
+    // For this example plugin, we only have the one "Gain" parameter, but
+    // this example serves to show an approach that scales to arbitrary numbers
+    // of parameters.
+    auto& params = processor.getParameters();
+    paramReadouts.resize(params.size());
+
+    for (auto& p : params)
     {
+        const auto index = p->getParameterIndex();
+        const auto value = p->getValue();
+
+        paramReadouts[index].value = value;
+        paramReadouts[index].dirty = true;
+
         p->addListener(this);
-        p->sendValueChangedMessageToListeners(p->getValue());
     }
 
-    // Lastly, start our timer for reporting meter values
+    // Lastly, start our timer for reporting meter and parameter values
     startTimerHz(30);
 
     // And of course set our editor size before we're done.
@@ -115,33 +125,48 @@ void GainPluginAudioProcessorEditor::resized()
 //==============================================================================
 void GainPluginAudioProcessorEditor::parameterValueChanged (int parameterIndex, float newValue)
 {
-    const auto& p = processor.getParameters()[parameterIndex];
-    juce::String id = p->getName(100);
-
-    if (auto* x = dynamic_cast<AudioProcessorParameterWithID*>(p))
-        id = x->paramID;
-
-    float defaultValue = p->getDefaultValue();
-    juce::String stringValue = p->getText(newValue, 0);
-
-    Component::SafePointer<blueprint::ReactApplicationRoot> safeAppRoot (&appRoot);
-
-    juce::MessageManager::callAsync([=]() {
-        if (blueprint::ReactApplicationRoot* root = safeAppRoot.getComponent())
-            root->dispatchEvent("parameterValueChange",
-                                parameterIndex,
-                                id,
-                                defaultValue,
-                                newValue,
-                                stringValue);
-    });
+    // This callback often runs on the realtime thread. To avoid any blocking
+    // or non-deterministic operations, we simply set some atomic values in our
+    // paramReadouts list. The timer running on the PluginEditor will check to
+    // propagate the updated values to the javascript interface.
+    paramReadouts[parameterIndex].value = newValue;
+    paramReadouts[parameterIndex].dirty = true;
 }
 
 void GainPluginAudioProcessorEditor::timerCallback()
 {
+    // Dispatch the gain peak values
     appRoot.dispatchEvent(
         "gainPeakValues",
         processor.getLeftChannelPeak(),
         processor.getRightChannelPeak()
     );
+
+    // Then we iterate here to dispatch any updated parameter values
+    for (int i = 0; i < paramReadouts.size(); ++i)
+    {
+        auto& pr = paramReadouts[i];
+
+        if (pr.dirty)
+        {
+            const float value = pr.value.load();
+            pr.dirty = false;
+
+            const auto& p = processor.getParameters()[i];
+            juce::String id = p->getName(100);
+
+            if (auto* x = dynamic_cast<AudioProcessorParameterWithID*>(p))
+                id = x->paramID;
+
+            float defaultValue = p->getDefaultValue();
+            juce::String stringValue = p->getText(value, 0);
+
+            appRoot.dispatchEvent("parameterValueChange",
+                                  i,
+                                  id,
+                                  defaultValue,
+                                  value,
+                                  stringValue);
+        }
+    }
 }

--- a/examples/GainPlugin/Source/PluginEditor.h
+++ b/examples/GainPlugin/Source/PluginEditor.h
@@ -35,10 +35,31 @@ public:
     void resized() override;
 
 private:
+    //==============================================================================
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
     GainPluginAudioProcessor& processor;
     blueprint::ReactApplicationRoot appRoot;
 
+    //==============================================================================
+    // The plugin editor holds an array of parameter value readouts which are
+    // propagated to the user interface. During parameter value changes on the
+    // realtime thread, we capture the values in this array of structs, then at
+    // 30Hz propagate the value changes via dispatching events to the jsui.
+    struct ParameterReadout {
+        std::atomic<float> value = 0.0;
+        std::atomic<bool> dirty = false;
+
+        ParameterReadout() = default;
+
+        ParameterReadout(const ParameterReadout& other) {
+            value = other.value.load();
+            dirty = other.dirty.load();
+        }
+    };
+
+    std::vector<ParameterReadout> paramReadouts;
+
+    //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GainPluginAudioProcessorEditor)
 };


### PR DESCRIPTION
This commit introduces a safer way of broadcasting parameter value updates to the javascript engine.

The way it was previously written, we had the `juce::MessageManager::callAsync` call in the parameter change callback. Although in practice that's not a huge deal, it is technically non-deterministic, and is running _way_ frequently on the realtime thread when a parameter is actually changing.

The way I had been planning to rewrite this involved the [ThrottleMap](https://github.com/nick-thompson/blueprint/blob/master/blueprint/core/blueprint_ThrottleMap.h) abstraction, but actually this also isn't a great solution for the realtime thread because of the syscall to collect the current time and the allocation upon inserting into the `std::map`.

This new way that I'm showing here I think is the safest and most efficient, and width this I'll propose that we remove the ThrottleMap altogether.