### PR TITLE
Fix performance issues around the LambdaReleasePool in EcmascriptEngine.

### DIFF
--- a/blueprint/core/blueprint_EcmascriptEngine.cpp
+++ b/blueprint/core/blueprint_EcmascriptEngine.cpp
@@ -412,14 +412,7 @@ namespace blueprint
     //==============================================================================
     void EcmascriptEngine::removeLambdaHelper (LambdaHelper* helper)
     {
-        for (size_t i = 0; i < lambdaReleasePool.size(); ++i)
-        {
-            if (lambdaReleasePool[i].get() == helper)
-            {
-                lambdaReleasePool.erase(lambdaReleasePool.begin() + i);
-                break;
-            }
-        }
+        lambdaReleasePool.erase(helper->id);
     }
 
     //==============================================================================
@@ -486,7 +479,7 @@ namespace blueprint
             duk_set_finalizer(ctx, -2);
 
             // And hang on to it!
-            lambdaReleasePool.push_back(std::move(helper));
+            lambdaReleasePool[helper->id] = std::move(helper);
             return;
         }
 

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <unordered_map>
 
 namespace blueprint
 {
@@ -153,11 +154,12 @@ namespace blueprint
             static duk_ret_t callbackFinalizer (duk_context* ctx);
 
             juce::var::NativeFunction callback;
+            juce::Uuid                id;
         };
 
         //==============================================================================
         duk_context* ctx;
-        std::vector<std::unique_ptr<LambdaHelper>> lambdaReleasePool;
+        std::unordered_map<juce::Uuid, std::unique_ptr<LambdaHelper>> lambdaReleasePool;
 
         //==============================================================================
         void removeLambdaHelper (LambdaHelper* helper);


### PR DESCRIPTION
 This fix resolves #79. The freeze was caused by an O(Nsquared) lookup
 on the LambdaReleasePool vector when GC kicked in and triggered our
 LambdaReleasePool finalizers.

 Note this also bumps juce from 5.4.1 to 5.4.2 as std::hash
 specialisation for juce::Uuid was added to the Uuid header in 5.4.2.