### PR TITLE
Add babel plugin-proposal-class-properties

### DIFF
--- a/examples/GainPlugin/Source/jsui/package.json
+++ b/examples/GainPlugin/Source/jsui/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.10.3",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0",
@@ -33,6 +34,9 @@
           "useESModules": false,
           "version": "7.0.0-beta.0"
         }
+      ],
+      [
+        "@babel/plugin-proposal-class-properties"
       ]
     ]
   },

--- a/packages/juce-blueprint/template/package.json
+++ b/packages/juce-blueprint/template/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.10.3",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0",
@@ -33,6 +34,9 @@
           "useESModules": false,
           "version": "7.0.0-beta.0"
         }
+      ],
+      [
+        "@babel/plugin-proposal-class-properties"
       ]
     ]
   },


### PR DESCRIPTION
I've not added this to the juce-blueprint packages dependencies yet @nick-thompson. I've added it for the purposes of client code. Let me know if it's worth having a the top level for future development. 

Relates to https://github.com/nick-thompson/blueprint/issues/69