### PR TITLE
Warning cleanups

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -57,6 +57,18 @@
 // configs.
 #include <juce_core/system/juce_TargetPlatform.h>
 
+#if __clang__
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+ #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+ #pragma clang diagnostic ignored "-Wswitch-enum"
+ #pragma clang diagnostic ignored "-Wshorten-64-to-32"
+ #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+ #pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
+ #pragma clang diagnostic ignored "-Wsign-conversion"
+ #pragma clang diagnostic ignored "-Wimplicit-float-conversion"
+#endif
+
 #include "duktape/src-noline/duktape.c"
 #include "duktape/extras/console/duk_console.c"
 
@@ -65,7 +77,6 @@
 #else
     #include "duktape/examples/debug-trans-socket/duk_trans_socket_unix.c"
 #endif
-
 
 #include "blueprint.h"
 
@@ -80,6 +91,10 @@
 #include "yoga/yoga/YGStyle.cpp"
 #include "yoga/yoga/YGValue.cpp"
 #include "yoga/yoga/Yoga.cpp"
+
+#if __clang__
+ #pragma clang diagnostic pop
+#endif
 
 // Enable compiler warnings
 #if _MSC_VER

--- a/blueprint/blueprint.h
+++ b/blueprint/blueprint.h
@@ -40,6 +40,21 @@
 #define YG_ENUM_BEGIN(name) enum name: unsigned
 #endif
 
+#if __clang__
+ // What the hell is wrong with library authors who don't run CI builds with strict warning checks
+ // and keep their code clean and tidy!?!? As well as missing their own bugs, it means that users of
+ // their library then hit a million warnings, so they reduce THEIR warning level to avoid the noise,
+ // (because they'll be too lazy/busy to fix it, or at least to add pragmas like this), and everyone's
+ // code just ends up a little bit worse..  [/rant]
+ #pragma clang diagnostic push
+ #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+ #pragma clang diagnostic ignored "-Wextra-semi"
+ #pragma clang diagnostic ignored "-Wsign-conversion"
+ #pragma clang diagnostic ignored "-Wswitch-enum"
+ #pragma clang diagnostic ignored "-Wunused-parameter"
+ #pragma clang diagnostic ignored "-Wimplicit-int-conversion"
+#endif
+
 #include "yoga/yoga/log.h"
 #include "yoga/yoga/event/event.h"
 #include "yoga/yoga/Utils.h"
@@ -57,6 +72,10 @@
 #include "duktape/src-noline/duktape.h"
 #include "duktape/extras/console/duk_console.h"
 #include "duktape/examples/debug-trans-socket/duk_trans_socket.h"
+
+#if __clang__
+ #pragma clang diagnostic pop
+#endif
 
 #include "core/blueprint_EcmascriptEngine.h"
 #include "core/blueprint_CanvasView.h"

--- a/blueprint/core/blueprint_CanvasView.h
+++ b/blueprint/core/blueprint_CanvasView.h
@@ -189,10 +189,8 @@ namespace blueprint
                         jassert(graphics);
                         jassert(args.numArguments == 1);
 
-                        const juce::String fontString = args.arguments[0].toString();
-
-                        juce::StringArray values;
-                        values.addTokens(fontString, " ");
+                        auto fontString = args.arguments[0].toString();
+                        auto values = juce::StringArray::fromTokens (fontString, juce::StringRef (" "), {});
 
                         jassert(values.size() >=2 && values.size() <= 4);
 
@@ -637,7 +635,7 @@ namespace blueprint
         {
         }
 
-        ~CanvasView()
+        ~CanvasView() override
         {
             if (isTimerRunning())
                 stopTimer();

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -28,7 +28,7 @@ namespace blueprint
 
         //==============================================================================
         EcmascriptEngine();
-        ~EcmascriptEngine();
+        ~EcmascriptEngine() override;
 
         //==============================================================================
         /** Constant representing an evaluation error */
@@ -158,7 +158,7 @@ namespace blueprint
         };
 
         //==============================================================================
-        duk_context* ctx;
+        duk_context* dukContext;
         std::unordered_map<juce::Uuid, std::unique_ptr<LambdaHelper>> lambdaReleasePool;
 
         //==============================================================================

--- a/blueprint/core/blueprint_GenericEditor.cpp
+++ b/blueprint/core/blueprint_GenericEditor.cpp
@@ -14,15 +14,15 @@ namespace blueprint
 {
 
     //==============================================================================
-    BlueprintGenericEditor::BlueprintGenericEditor (juce::AudioProcessor* processor, const juce::File& bundle, juce::AudioProcessorValueTreeState* vts)
-        : juce::AudioProcessorEditor(processor), valueTreeState(vts)
+    BlueprintGenericEditor::BlueprintGenericEditor (juce::AudioProcessor& proc, const juce::File& bundle, juce::AudioProcessorValueTreeState* vts)
+        : juce::AudioProcessorEditor (proc), valueTreeState(vts)
     {
         // Sanity check
         jassert (bundle.existsAsFile());
         bundleFile = bundle;
 
         // Bind parameter listeners
-        for (auto& p : processor->getParameters())
+        for (auto& p : proc.getParameters())
             p->addListener(this);
 
         // Setup the ReactApplicationRoot callbacks and evaluate the supplied JS code/bundle
@@ -102,9 +102,8 @@ namespace blueprint
                     "beginParameterChangeGesture",
                     [](void* stash, const juce::var::NativeFunctionArgs& args) {
                         auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
-                        const juce::String& paramId = args.arguments[0].toString();
 
-                        if (auto* parameter = state->getParameter(paramId))
+                        if (auto* parameter = state->getParameter (args.arguments[0].toString()))
                             parameter->beginChangeGesture();
 
                         return juce::var::undefined();
@@ -116,11 +115,9 @@ namespace blueprint
                     "setParameterValueNotifyingHost",
                     [](void* stash, const juce::var::NativeFunctionArgs& args) {
                         auto* state = reinterpret_cast<juce::AudioProcessorValueTreeState*>(stash);
-                        const juce::String& paramId = args.arguments[0].toString();
-                        const double value = args.arguments[1];
 
-                        if (auto* parameter = state->getParameter(paramId))
-                            parameter->setValueNotifyingHost(value);
+                        if (auto* parameter = state->getParameter (args.arguments[0].toString()))
+                            parameter->setValueNotifyingHost (static_cast<float> (args.arguments[1]));
 
                         return juce::var::undefined();
                     },

--- a/blueprint/core/blueprint_GenericEditor.h
+++ b/blueprint/core/blueprint_GenericEditor.h
@@ -30,9 +30,9 @@ namespace blueprint
     {
     public:
         //==============================================================================
-        BlueprintGenericEditor (juce::AudioProcessor*, const juce::File&, juce::AudioProcessorValueTreeState* = nullptr);
+        BlueprintGenericEditor (juce::AudioProcessor&, const juce::File&, juce::AudioProcessorValueTreeState* = nullptr);
 
-        ~BlueprintGenericEditor();
+        ~BlueprintGenericEditor() override;
 
         //==============================================================================
         /** Implement the AudioProcessorParameter::Listener interface. */

--- a/blueprint/core/blueprint_RawTextView.h
+++ b/blueprint/core/blueprint_RawTextView.h
@@ -34,7 +34,7 @@ namespace blueprint
         RawTextView(const juce::String& text) : _text(text) {}
 
         //==============================================================================
-        void setProperty (const juce::Identifier& name, const juce::var& newValue) override
+        void setProperty (const juce::Identifier&, const juce::var&) override
         {
             throw std::logic_error("A RawTextView can't receive properties.");
         }

--- a/blueprint/core/blueprint_ScrollView.h
+++ b/blueprint/core/blueprint_ScrollView.h
@@ -47,6 +47,7 @@ namespace blueprint
 
         void addChild (View* childView, int index = -1) override
         {
+            juce::ignoreUnused (index);
             jassert (viewport.getViewedComponent() == nullptr);
             viewport.setViewedComponent(childView, false);
         }

--- a/blueprint/core/blueprint_TextShadowView.cpp
+++ b/blueprint/core/blueprint_TextShadowView.cpp
@@ -14,9 +14,9 @@ namespace blueprint
 {
 
     //==============================================================================
-    YGSize measureTextNode(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode) {
-        TextShadowView* context = reinterpret_cast<TextShadowView*>(YGNodeGetContext(node));
-        TextView* view = dynamic_cast<TextView*>(context->getAssociatedView());
+    YGSize measureTextNode(YGNodeRef node, float width, YGMeasureMode /*widthMode*/, float /*height*/, YGMeasureMode /*heightMode*/) {
+        auto context = reinterpret_cast<TextShadowView*>(YGNodeGetContext(node));
+        auto view = dynamic_cast<TextView*>(context->getAssociatedView());
 
         jassert (view != nullptr);
 

--- a/blueprint/core/blueprint_TextShadowView.h
+++ b/blueprint/core/blueprint_TextShadowView.h
@@ -52,6 +52,8 @@ namespace blueprint
         /** Override the default ShadowView behavior to explicitly error. */
         void addChild (ShadowView* childView, int index = -1) override
         {
+            juce::ignoreUnused (index);
+
             if (childView != nullptr)
             {
                 throw std::logic_error("TextShadowView cannot take children.");

--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -26,30 +26,23 @@ namespace blueprint
     {
         props.set(name, value);
 
-        if (name == juce::Identifier("interceptClickEvents"))
+        if (name == juce::StringRef ("interceptClickEvents"))
         {
-            int flag = value;
+            switch (static_cast<int> (value))
+            {
+                case 0:      setInterceptsMouseClicks (false, false);  break;
+                case 1:      setInterceptsMouseClicks (true,  true);   break;
+                case 2:      setInterceptsMouseClicks (true,  false);  break;
+                case 3:      setInterceptsMouseClicks (false, true);   break;
 
-            switch (flag) {
-                case 0:
-                    setInterceptsMouseClicks(false, false);
-                    break;
-                case 2:
-                    setInterceptsMouseClicks(true, false);
-                    break;
-                case 3:
-                    setInterceptsMouseClicks(false, true);
-                    break;
-                case 1:
-                default:
-                    setInterceptsMouseClicks(true, true);
-                    break;
+                default:     setInterceptsMouseClicks (true,  true);   break;
             }
         }
 
-        if (name == juce::Identifier("opacity"))
-            setAlpha((double) value);
-        if (name == juce::Identifier("refId"))
+        if (name == juce::StringRef("opacity"))
+            setAlpha(static_cast<float> (value));
+
+        if (name == juce::StringRef("refId"))
             _refId = juce::Identifier(value.toString());
     }
 
@@ -66,9 +59,9 @@ namespace blueprint
         // Update transforms
         if (props.contains("transform-rotate"))
         {
-            float cxRelParent = cachedFloatBounds.getX() + cachedFloatBounds.getWidth() * 0.5f;
-            float cyRelParent = cachedFloatBounds.getY() + cachedFloatBounds.getHeight() * 0.5f;
-            double angle = props["transform-rotate"];
+            auto cxRelParent = cachedFloatBounds.getX() + cachedFloatBounds.getWidth() * 0.5f;
+            auto cyRelParent = cachedFloatBounds.getY() + cachedFloatBounds.getHeight() * 0.5f;
+            auto angle = static_cast<float> (props["transform-rotate"]);
 
             setTransform(juce::AffineTransform::rotation(angle, cxRelParent, cyRelParent));
         }
@@ -77,7 +70,7 @@ namespace blueprint
     //==============================================================================
     float View::getResolvedLengthProperty (const juce::String& name, float axisLength)
     {
-        float ret = 0.0;
+        float ret = 0;
 
         if (props.contains(name))
         {
@@ -117,7 +110,7 @@ namespace blueprint
         else if (props.contains("border-color") && props.contains("border-width"))
         {
             juce::Path border;
-            juce::Colour c = juce::Colour::fromString(props["border-color"].toString());
+            auto c = juce::Colour::fromString(props["border-color"].toString());
             float borderWidth = props["border-width"];
 
             // Note this little bounds trick. When a Path is stroked, the line width extends
@@ -125,9 +118,9 @@ namespace blueprint
             // line is the exact bounding box then the component clipping makes the corners
             // appear to have different radii on the interior and exterior of the box.
             auto borderBounds = getLocalBounds().toFloat().reduced(borderWidth * 0.5f);
-            const float width = borderBounds.getWidth();
-            const float height = borderBounds.getHeight();
-            const float minLength = std::min(width, height);
+            auto width  = borderBounds.getWidth();
+            auto height = borderBounds.getHeight();
+            auto minLength = std::min(width, height);
             float borderRadius = getResolvedLengthProperty("border-radius", minLength);
 
             border.addRoundedRectangle(borderBounds, borderRadius);
@@ -143,7 +136,6 @@ namespace blueprint
             if (!c.isTransparent())
                 g.fillAll(c);
         }
-
     }
 
     //==============================================================================
@@ -152,34 +144,33 @@ namespace blueprint
         auto w = cachedFloatBounds.getWidth();
         auto h = cachedFloatBounds.getHeight();
 
-        if (ReactApplicationRoot* root = findParentComponentOfClass<ReactApplicationRoot>())
+        if (auto root = findParentComponentOfClass<ReactApplicationRoot>())
             root->dispatchViewEvent(getViewId(), "Measure", w, h);
     }
 
     void View::mouseDown (const juce::MouseEvent& e)
     {
-        if (ReactApplicationRoot* root = findParentComponentOfClass<ReactApplicationRoot>())
+        if (auto root = findParentComponentOfClass<ReactApplicationRoot>())
             root->dispatchViewEvent(getViewId(), "MouseDown", e.x, e.y);
     }
 
     void View::mouseUp (const juce::MouseEvent& e)
     {
-        if (ReactApplicationRoot* root = findParentComponentOfClass<ReactApplicationRoot>())
+        if (auto root = findParentComponentOfClass<ReactApplicationRoot>())
             root->dispatchViewEvent(getViewId(), "MouseUp", e.x, e.y);
     }
 
     void View::mouseDrag (const juce::MouseEvent& e)
     {
-        float mouseDownX = e.mouseDownPosition.getX();
-        float mouseDownY = e.mouseDownPosition.getY();
+        auto mouseDown = e.mouseDownPosition;
 
-        if (ReactApplicationRoot* root = findParentComponentOfClass<ReactApplicationRoot>())
-            root->dispatchViewEvent(getViewId(), "MouseDrag", e.x, e.y, mouseDownX, mouseDownY);
+        if (auto root = findParentComponentOfClass<ReactApplicationRoot>())
+            root->dispatchViewEvent(getViewId(), "MouseDrag", e.x, e.y, mouseDown.x, mouseDown.y);
     }
 
     void View::mouseDoubleClick (const juce::MouseEvent& e)
     {
-        if (ReactApplicationRoot* root = findParentComponentOfClass<ReactApplicationRoot>())
+        if (auto root = findParentComponentOfClass<ReactApplicationRoot>())
             root->dispatchViewEvent(getViewId(), "MouseDoubleClick", e.x, e.y);
     }
 }

--- a/blueprint/core/blueprint_View.h
+++ b/blueprint/core/blueprint_View.h
@@ -31,7 +31,7 @@ namespace blueprint
     public:
         //==============================================================================
         View() = default;
-        virtual ~View() = default;
+        ~View() override = default;
 
         //==============================================================================
         /** Returns this view's identifier. */


### PR DESCRIPTION
This is basically a bunch of changes I needed to get the code working in a project that has a sensible level of warnings enabled. 

Mostly innocuous stuff, though I did spot a string-literal-to-bool implicit cast :)

Not sure what you guys do for CI, but if there's a projucer project involved, you should really enable the "Add Recommended Compiler Warning Flags" options for it.