### PR TITLE
Distinguish temporary and persistent native callbacks with lightfuncs

### DIFF
--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -177,7 +177,7 @@ namespace blueprint
         uint32_t nextHelperId = 0;
         int32_t nextMagicInt = 0;
         std::unordered_map<uint32_t, std::unique_ptr<LambdaHelper>> persistentReleasePool;
-        std::unordered_map<int16_t, std::unique_ptr<LambdaHelper>> temporaryReleasePool;
+        std::array<std::unique_ptr<LambdaHelper>, 255> temporaryReleasePool;
 
         //==============================================================================
         /** Helper for cleaning up native function temporaries. */

--- a/blueprint/core/blueprint_ReactApplicationRoot.h
+++ b/blueprint/core/blueprint_ReactApplicationRoot.h
@@ -418,9 +418,6 @@ namespace blueprint
             JUCE_ASSERT_MESSAGE_THREAD
             jassert(handler);
 
-            // TODO: Here we have a case of `invoke` where the callback is not a temporary. Perhaps
-            // we want two different `invoke` methods: one for immeidately cleaning up temporaries,
-            // and one which persists native functions. `pinvoke`? `invokeWithPersistentNativeFunctions`?
             return engine.invoke("__BlueprintNative__.subscribe", eventType, std::move(handler));
         }
 


### PR DESCRIPTION
@JoshMarler this is a follow up to #89, adding one more commit that distinguishes temporary native callbacks (e.g. canvas context methods) from persistent native callbacks (e.g. registerNativeMethod), using a limited pool of lightfuncs for the former and our duk_finalizer approach for the latter, with duktape running it's gc whenever it deems appropriate.

After a very cursory profile of the GainPlugin, this looks to me like a 5x performance speedup on the canvas paints, which is awesomeee.

Take a look, let me know if you like the approach, and I'd also be very curious to hear a profile with your app!