### PR TITLE
package.json tweaks after GainPlugin source depth move

### DIFF
--- a/examples/GainPlugin/jsui/package-lock.json
+++ b/examples/GainPlugin/jsui/package-lock.json
@@ -3416,7 +3416,7 @@
       }
     },
     "juce-blueprint": {
-      "version": "file:../../../../packages/juce-blueprint",
+      "version": "file:../../../packages/juce-blueprint",
       "requires": {
         "@babel/runtime-corejs3": "^7.11.2",
         "core-js": "2.6.0",

--- a/examples/GainPlugin/jsui/package.json
+++ b/examples/GainPlugin/jsui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.11.2",
     "file-loader": "6.1.0",
-    "juce-blueprint": "file:../../../../packages/juce-blueprint",
+    "juce-blueprint": "file:../../../packages/juce-blueprint",
     "react": "^16.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, super glad to see cmake underway!

It seems some `package{,-lock}.json` bumps are needed after the elimination of `GainPlugin/Source`.