### PR TITLE
[bug] Fix crash on ReactApplicationRoot destruction

### DIFF
--- a/blueprint/core/blueprint_ReactApplicationRoot.h
+++ b/blueprint/core/blueprint_ReactApplicationRoot.h
@@ -136,6 +136,11 @@ namespace blueprint
             setWantsKeyboardFocus(true);
 #endif
         }
+        
+        ~ReactApplicationRoot()
+        {
+            props.clear();
+        }
 
         //==============================================================================
         /** Override the default View behavior.  */


### PR DESCRIPTION
  Bug raised by Jules. ReactApplicationRoot inherits from View and also
  contains an EcmascriptEngine instance. When the ReactApplicationRoot
  destructor is called the EcmascriptEngine instance is destroyed. We
  then fall into the base View destructor which is holding some
  juce::var objects which hold lambdas that have captured the now
  destroyed EcmascriptEngine instance. See
  EcmascriptEngine::readVarFromDukStack.

  Quick and dirty fix here is to clear the ReactApplicationRoot's props
  before EcmascriptEngine goes out of scope. There may be a more elegant
  solution for this but don't have time to dig deeper right now.

  The core issue is that CallbackHelper in EcmascriptEngine is captured
  in juce::var lambda's and CallbackHelper holds a pointer to the duk
  context owned by the destroyed EcmascriptEngine instance.
  CallbackHelper's destructor attempts to use the duk context.
  CallbackHelper could store a weak reference to the duk_ctx object but
  I'm not convined that is the right fix here.

@nick-thompson, explanation of bug in commit message. This is a quick and dirty fix to stop disruption to users if you want to whack something straight in. The real problem lies in capture blocks when `CallbackHelper` is destroyed and still references `EcmascriptEngine's` duktape context. Possible the context could be stored in shared_ptr and `CallbackHelper` could take `weak_ptr<duk_ctx>` but I'm not convinced that's the right shape. In the middle of some other things so will have to look at this in earnest later.  