### PR TITLE
[Breaking] Fix evaluate() overload for non-explicit File constructor

### DIFF
--- a/blueprint/core/blueprint_AppHarness.h
+++ b/blueprint/core/blueprint_AppHarness.h
@@ -70,7 +70,6 @@ namespace blueprint
          *     };
          *
          *     harness.watch(myAppBundle);
-         *     appRoot.evaluate(myAppBundle);
          *
          *     // Not strictly required if JUCE_DEBUG set.
          *     harness.start();
@@ -110,7 +109,6 @@ namespace blueprint
          *     };
          *
          *     harness.watch(myAppBundle);
-         *     appRoot.evaluate(myAppBundle);
          *
          *     // Not strictly required if JUCE_DEBUG set.
          *     harness.start();
@@ -143,7 +141,6 @@ namespace blueprint
          *     };
          *
          *     harness.watch(myAppBundle);
-         *     appRoot.evaluate(myAppBundle);
          *
          *     // Not strictly required if JUCE_DEBUG set.
          *     harness.start();
@@ -174,7 +171,6 @@ namespace blueprint
          *     };
          *
          *     harness.watch(myAppBundle);
-         *     appRoot.evaluate(myAppBundle);
          *
          *     // Not strictly required if JUCE_DEBUG set.
          *     harness.start();

--- a/blueprint/core/blueprint_EcmascriptEngine.cpp
+++ b/blueprint/core/blueprint_EcmascriptEngine.cpp
@@ -152,7 +152,7 @@ namespace blueprint
         }
 
         //==============================================================================
-        juce::var evaluate (const juce::String& code)
+        juce::var evaluateInline (const juce::String& code)
         {
             jassert(code.isNotEmpty());
             auto* ctxRawPtr = dukContext.get();
@@ -698,9 +698,9 @@ namespace blueprint
         : mPimpl(std::make_unique<Pimpl>()) {}
 
     //==============================================================================
-    juce::var EcmascriptEngine::evaluate (const juce::String& code)
+    juce::var EcmascriptEngine::evaluateInline (const juce::String& code)
     {
-        return mPimpl->evaluate(code);
+        return mPimpl->evaluateInline(code);
     }
 
     juce::var EcmascriptEngine::evaluate (const juce::File& code)

--- a/blueprint/core/blueprint_EcmascriptEngine.h
+++ b/blueprint/core/blueprint_EcmascriptEngine.h
@@ -64,7 +64,7 @@ namespace blueprint
          *  @returns juce::var result of the evaluation
          *  @throws EcmascriptEngine::Error in the event of an evaluation error
          */
-        juce::var evaluate (const juce::String& code);
+        juce::var evaluateInline (const juce::String& code);
         juce::var evaluate (const juce::File& code);
 
         //==============================================================================

--- a/docs/New_Project.md
+++ b/docs/New_Project.md
@@ -103,7 +103,7 @@ public:
         File bundle = sourceDir.getChildFile("jsui/build/js/main.js");
 
         addAndMakeVisible(appRoot);
-        appRoot.evaluate(bundle.loadFileAsString());
+        appRoot.evaluate(bundle);
 
         setSize(400, 300);
     }


### PR DESCRIPTION
@JoshMarler what do you think of this?

This fixes the issue we've been seeing in e.g. #108, which is caused by an implicit construction of a `juce::File` when trying to use `ReactApplicationRoot::evaluate` with a string. This is a breaking change to differentiate evaluating a file from evaluating a string, but I'm not sure of any other way to do it.