### PR TITLE
Add missing babel plugin dependency (recommended for TS)

### DIFF
--- a/packages/juce-blueprint/package.json
+++ b/packages/juce-blueprint/package.json
@@ -9,6 +9,7 @@
     "@babel/cli": "^7.10.0",
     "@babel/core": "^7.11.1",
     "@babel/plugin-transform-runtime": "^7.11.0",
+    "@babel/plugin-proposal-class-properties": "^7.11.0",
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",


### PR DESCRIPTION
@nick-thompson , Noticed on a fresh install/build from scratch this babel dependency is missing. Referenced in the `babel.config.js` for Typescript. 