### PR TITLE
Support CSS function-style properties

### DIFF
--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -116,13 +116,25 @@ namespace blueprint
         cachedFloatBounds = bounds;
 
         // Update transforms
-        if (props.contains("transform-rotate"))
+        if (props.contains("transform-matrix"))
         {
-            auto cxRelParent = cachedFloatBounds.getX() + cachedFloatBounds.getWidth() * 0.5f;
-            auto cyRelParent = cachedFloatBounds.getY() + cachedFloatBounds.getHeight() * 0.5f;
-            auto angle = static_cast<float> (props["transform-rotate"]);
+            const juce::var& matrix = props["transform-matrix"];
+            if(matrix.isArray() && matrix.getArray()->size() >= 16) {
+              const juce::Array<juce::var> &m = *matrix.getArray();
 
-            setTransform(juce::AffineTransform::rotation(angle, cxRelParent, cyRelParent));
+              auto cxRelParent = cachedFloatBounds.getX() + cachedFloatBounds.getWidth() * 0.5f;
+              auto cyRelParent = cachedFloatBounds.getY() + cachedFloatBounds.getHeight() * 0.5f;
+
+              const auto translateToOrigin = juce::AffineTransform::translation(cxRelParent * -1.0f, cyRelParent * -1.0f);
+              // set 2d homogeneous matrix using 3d homogeneous matrix
+              const auto transform = juce::AffineTransform(
+                m[0], m[1], m[3],
+                m[4], m[5], m[7]
+              );
+              const auto translateFromOrigin = juce::AffineTransform::translation(cxRelParent, cyRelParent);
+
+              setTransform(translateToOrigin.followedBy(transform).followedBy(translateFromOrigin));
+            }
         }
     }
 

--- a/examples/GainPlugin/jsui/src/Slider.js
+++ b/examples/GainPlugin/jsui/src/Slider.js
@@ -141,7 +141,7 @@ class Slider extends Component {
   }
 
   render() {
-    const {value, width, height} = this.state;
+    const { value, width, height } = this.state;
 
     return (
       <View
@@ -166,7 +166,7 @@ const styles = {
     'position': 'absolute',
     'left': 0.0,
     'top': 0.0,
-    'transform-rotate': Math.PI * 1.25,
+    transform: 'rotate(225deg)'
   },
 };
 

--- a/packages/react-juce/package-lock.json
+++ b/packages/react-juce/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-juce",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3711,6 +3711,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "matrix-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/matrix-js/-/matrix-js-1.5.1.tgz",
+      "integrity": "sha512-9RXFX//tQ3nOhwovkSPZho7JfCvVMYJAn5WP1pnOWefw/IrZiPkv+41RtSsHFBOhx4zI0ZM/uo6UWEcEjWifGg=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/packages/react-juce/package.json
+++ b/packages/react-juce/package.json
@@ -36,6 +36,7 @@
     "@babel/runtime-corejs3": "^7.11.2",
     "core-js": "2.6.0",
     "invariant": "^2.2.4",
+    "matrix-js": "^1.5.1",
     "react-reconciler": "^0.17.2"
   },
   "peerDependencies": {

--- a/packages/react-juce/src/lib/BlueprintBackend.ts
+++ b/packages/react-juce/src/lib/BlueprintBackend.ts
@@ -1,6 +1,7 @@
 import SyntheticEvents,
        { SyntheticMouseEvent,
          SyntheticKeyboardEvent } from './SyntheticEvents'
+import { macroPropertyGetters } from './MacroProperties';
 
 /* global __BlueprintNative__:false */
 
@@ -109,6 +110,13 @@ export class ViewInstance {
     // to our renderer's setProperty from the reconciler.
     if (propKey === 'viewRef') {
       value.current = this;
+      return;
+    }
+
+    if (macroPropertyGetters.hasOwnProperty(propKey)) {
+      for (const [k, v] of macroPropertyGetters[propKey](value))
+        //@ts-ignore
+        __BlueprintNative__.setViewProperty(this._id, k, v);
       return;
     }
 

--- a/packages/react-juce/src/lib/MacroProperties/Transform.ts
+++ b/packages/react-juce/src/lib/MacroProperties/Transform.ts
@@ -1,0 +1,158 @@
+import { TPropertyAssignment } from "./types";
+import { getMacroCalls } from "./util";
+import matrix from 'matrix-js';
+
+const rotateMultipliers = {
+  deg: Math.PI / 180.0,
+  grad: Math.PI / 200.0,
+  rad: 1,
+  turn: 2 * Math.PI,
+};
+
+const angleUnitMatcher = new RegExp(
+  `(-?[0-9]*\.?[0-9]+)(${Object.keys(rotateMultipliers).join("|")}|)$`
+);
+
+const toRadians = (arg: string) => {
+  // @ts-ignore
+  let [, angle, unit] = angleUnitMatcher.exec(arg);
+  let angleFloat = parseFloat(angle);
+  if (angleFloat === NaN) return NaN;
+  if (unit === "" && angleFloat !== 0) return NaN;
+  angleFloat *= rotateMultipliers[unit] || 1;
+  return angleFloat;
+}
+
+const stringArgsToFloat = (...args: string[]) => args.map(parseFloat);
+const stringArgsToRadians = (...args: string[]) => args.map(toRadians);
+
+const identity = matrix([
+  [1, 0, 0, 0],
+  [0, 1, 0, 0],
+  [0, 0, 1, 0],
+  [0, 0, 0, 1],
+]);
+
+const rotate3d = (x: number, y: number, z: number, theta: number) => {
+  const sinTheta = Math.sin(theta);
+  const cosTheta = Math.cos(theta);
+  const r = Math.sqrt(x ** 2 + y ** 2 + z ** 2)
+  if (r === 0) { return identity; }
+  const [u, v, w] = [x / r, y / r, z / r];
+
+  return matrix([
+    [cosTheta + (1 - cosTheta) * u ** 2, u * v * (1 - cosTheta) - w * sinTheta, u * w * (1 - cosTheta) + v * sinTheta, 0],
+    [v * u * (1 - cosTheta) + w * sinTheta, cosTheta + (1 - cosTheta) * v ** 2, v * w * (1 - cosTheta) - u * sinTheta, 0],
+    [w * u * (1 - cosTheta) - v * sinTheta, w * v * (1 - cosTheta) + u * sinTheta, cosTheta + (1 - cosTheta) * w ** 2, 0],
+    [0, 0, 0, 1]
+  ]);
+}
+
+const rotateX = (theta: number) => rotate3d(1, 0, 0, theta);
+const rotateY = (theta: number) => rotate3d(0, 1, 0, theta);
+const rotateZ = (theta: number) => rotate3d(0, 0, 1, theta);
+
+const scale3d = (sx = 1, sy = 1, sz = 1) => matrix([
+  [sx, 0, 0, 0],
+  [0, sy, 0, 0],
+  [0, 0, sz, 0],
+  [0, 0, 0, 1]
+]);
+
+const scale = (sx = 1, sy = 1) => scale3d(sx, sy);
+const scaleX = (sx = 1) => scale(sx);
+const scaleY = (sy = 1) => scale(1, sy);
+const scaleZ = (sz = 1) => scale3d(1, 1, sz);
+
+const skew = (alpha = 0, beta = 0) => {
+  const tanAlpha = Math.tan(alpha) || 0;
+  const tanBeta = Math.tan(beta) || 0;
+  return matrix([
+    [1 + tanAlpha * tanBeta, tanAlpha, 0, 0],
+    [tanBeta, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+  ]);
+}
+
+const skewX = (theta: number) => skew(theta);
+const skewY = (theta: number) => skew(0, theta);
+
+const translate3d = (dx = 0, dy = 0, dz = 0) => matrix([
+  [1, 0, 0, dx],
+  [0, 1, 0, dy],
+  [0, 0, 1, dz],
+  [0, 0, 0, 1]
+]);
+
+const translate = (dx = 0, dy = 0) => translate3d(dx, dy, 0);
+const translateX = (dx = 0) => translate3d(dx);
+const translateY = (dy = 0) => translate3d(0, dy);
+const translateZ = (dz = 0) => translate3d(0, 0, dz);
+
+const argsTransformMap = {
+  matrix: stringArgsToFloat,
+  matrix3d: stringArgsToFloat,
+  rotate: stringArgsToRadians,
+  rotate3d: (x, y, z, t) => [...stringArgsToFloat(x, y, z), toRadians(t)],
+  rotateX: stringArgsToRadians,
+  rotateY: stringArgsToRadians,
+  rotateZ: stringArgsToRadians,
+  scale: stringArgsToFloat,
+  scale3d: stringArgsToFloat,
+  scaleX: stringArgsToFloat,
+  scaleY: stringArgsToFloat,
+  scaleZ: stringArgsToFloat,
+  skew: stringArgsToRadians,
+  skewX: stringArgsToRadians,
+  skewY: stringArgsToRadians,
+  translate: stringArgsToFloat,
+  translate3d: stringArgsToFloat,
+  translateX: stringArgsToFloat,
+  translateY: stringArgsToFloat,
+  translateZ: stringArgsToFloat,
+}
+
+const transformMatrixMap = {
+  none: identity,
+  matrix: (l11, l12, dx, l21, l22, dy) => matrix([
+    [l11, l12, 0, dx],
+    [l21, l22, 0, dy],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1]
+  ]),
+  matrix3d: (m11, m12, m13, m14, m21, m22, m23, m24, m31, m32, m33, m34, m41, m42, m43, m44) => matrix([
+    [m11, m12, m13, m14],
+    [m21, m22, m23, m24],
+    [m31, m32, m33, m34],
+    [m41, m42, m43, m44],
+  ]),
+  // perspective: ()=>identity, // TODO
+  rotate: rotateZ,
+  rotateX, rotateY, rotateZ,
+  scale, scale3d, scaleX, scaleY, scaleZ,
+  skew, skewX, skewY,
+  translate, translate3d, translateX, translateY, translateZ
+};
+
+const matrixToArray = m => m().reduce((acc, v) => [...acc, ...v]);
+
+export default function (value: string): TPropertyAssignment[] {
+  const calls = getMacroCalls(value);
+  // operations performed right to left
+  // i.e. transform: translateY(20) rotate(90deg)
+  // means rotate 90 degrees, then translate up 20
+  // so we reverse in-place the calls array which initially
+  // has the translation first followed by the rotate.
+  calls.reverse()
+  //@ts-ignore
+  const transformMatrix = calls.reduce((acc, { macro: f, args }) => {
+    if (!transformMatrixMap.hasOwnProperty(f)) {
+      return acc;
+    }
+    const argsTransform = argsTransformMap[f] || (() => args);
+    const transform = transformMatrixMap[f](...argsTransform(...args));
+    return matrix(transform.prod(acc));
+  }, identity);
+  return [['transform-matrix', matrixToArray(transformMatrix)]];
+}

--- a/packages/react-juce/src/lib/MacroProperties/index.ts
+++ b/packages/react-juce/src/lib/MacroProperties/index.ts
@@ -1,0 +1,5 @@
+import transformPropertiesGetter from "./Transform";
+
+export const macroPropertyGetters = {
+  transform: transformPropertiesGetter
+};

--- a/packages/react-juce/src/lib/MacroProperties/types.d.ts
+++ b/packages/react-juce/src/lib/MacroProperties/types.d.ts
@@ -1,0 +1,6 @@
+export type TMacroCall = {
+  macro: string;
+  args: string[];
+};
+
+export type TPropertyAssignment = [string, string | number];

--- a/packages/react-juce/src/lib/MacroProperties/util.ts
+++ b/packages/react-juce/src/lib/MacroProperties/util.ts
@@ -1,0 +1,31 @@
+import { TMacroCall } from "./types";
+
+// don't try too hard, we don't need to support qouted strings containing commas etc.
+export const splitArgs = (a: string) => {
+  const argArray = a.trim().split(/\s*,\s*/);
+  if (argArray.length === 1 && argArray[0] === '') return [];
+  return argArray;
+}
+
+export const getMacroCalls = (s: string): TMacroCall[] => {
+  const macroMatcher = String.raw`([a-zA-Z0-9]+)\(([^)]*)\)`;
+  let r = new RegExp(macroMatcher, "g");
+  // the rest would be trivial with matchAll
+  // which duktape sadly lacks
+  const matches = s.match(r);
+  if (!matches) return [];
+  // unset "g" flag, otherwise r.exec returns null when multiple matches occurred
+  r = new RegExp(macroMatcher);
+  const macroCalls = [];
+  for (const match of matches) {
+    // @ts-ignore
+    const [, macro, args] = r.exec(match);
+    macroCalls.push({
+      // @ts-ignore
+      macro,
+      // @ts-ignore
+      args: splitArgs(args),
+    });
+  }
+  return macroCalls;
+};


### PR DESCRIPTION
Move from non-css property names like `transform-rotate` to their css counterparts with functional values.

Allows definition of a set of valid "macro calls" for a css property (e.g. for `transform` we can define `rotate(...)`, `skew(...)`, ...) to be translated to individual blueprint property: string/float pairs (e.g. `transform: rotate(90deg) => transform-rotate: pi/4`).

Only `transform: rotate() => transform-rotate: ...` has been implemented here as an example.

The optional second argument to `getMacroCalls` specifies an array of valid functional property values (otherwise it'll accept any alphanumeric).  To develop valid functional values for `transform` further, you'd add to the array `["rotate"]` and handle in `Transform.default`.