### PR TITLE
Remove additional warnings causing duktape compile to fail on Mac

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -57,6 +57,8 @@
  #pragma clang diagnostic ignored "-Wshorten-64-to-32"
  #pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
  #pragma clang diagnostic ignored "-Wsign-conversion"
+ #pragma clang diagnostic ignored "-Wused-but-marked-unused"
+ #pragma clang diagnostic ignored "-Wformat-nonliteral"
  #if __clang_major__ > 10
   #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
   #pragma clang diagnostic ignored "-Wimplicit-int-conversion"


### PR DESCRIPTION
@nick-thompson, Hit some additional errors on mac. Disabling these warnings prior to duktape include resolves. 