### PR TITLE
Better ReactApplicationRoot method binding

### DIFF
--- a/examples/GainPlugin/jsui/package-lock.json
+++ b/examples/GainPlugin/jsui/package-lock.json
@@ -3990,9 +3990,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-juce": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/react-juce/-/react-juce-0.2.0.tgz",
-      "integrity": "sha512-i6Q7H507ECRbYm456mroOUYM4JarsjlTnLKdMpkULpZwQ1/0t1tuuLTJ2vZPbvlbGMHY++9LBKBBOLtHrxGsBw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/react-juce/-/react-juce-0.2.1.tgz",
+      "integrity": "sha512-FKivvVXPaf2RanUiYyNdhbyFUcQzvOAIKwedNaZiq7DhFeq7UneQx3rzvKAJdvJ3dvocGLqPDfMFt02wA4yCKg==",
       "requires": {
         "@babel/runtime-corejs3": "^7.11.2",
         "core-js": "2.6.0",

--- a/examples/GainPlugin/jsui/package.json
+++ b/examples/GainPlugin/jsui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime-corejs3": "^7.11.2",
-    "react-juce": "^0.2.0",
+    "react-juce": "^0.2.1",
     "file-loader": "6.1.0",
     "react": "^16.13.1"
   },

--- a/packages/react-juce/package-lock.json
+++ b/packages/react-juce/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-juce",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-juce/package.json
+++ b/packages/react-juce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-juce",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Write cross-platform native apps with React.js and JUCE.",
   "repository": {
     "type": "git",

--- a/packages/react-juce/src/lib/BlueprintBackend.ts
+++ b/packages/react-juce/src/lib/BlueprintBackend.ts
@@ -75,7 +75,7 @@ export class ViewInstance {
     this._children.push(childInstance);
 
     //@ts-ignore
-    return __BlueprintNative__.addChild(this._id, childInstance._id);
+    return __BlueprintNative__.addChild(this._id, childInstance._id, -1);
   }
 
   insertChild(childInstance: Instance, index: number): any {


### PR DESCRIPTION
Addresses #103 and cleans up a bunch of `jassert`/unpacking of `juce::var::NativeFunctionArgs`.

I already bumped react-juce@0.2.1 and published it because the change to the react-juce package is non-breaking either way.

LMK if this looks good to you @JoshMarler 