### PR TITLE
Apply statically initialised juce::Identifiers for View props

### DIFF
--- a/blueprint/core/blueprint_CanvasView.h
+++ b/blueprint/core/blueprint_CanvasView.h
@@ -668,6 +668,10 @@ namespace blueprint
     {
     public:
         //==============================================================================
+        static const inline juce::Identifier animateProp = "animate";
+        static const inline juce::Identifier onDrawProp  = "onDraw";
+
+        //==============================================================================
         CanvasView()
             : ctx(new CanvasContext())
         {
@@ -684,7 +688,7 @@ namespace blueprint
         {
             View::setProperty(name, value);
 
-            if (name == juce::Identifier("animate"))
+            if (name == animateProp)
             {
                 bool shouldAnimate = value;
 
@@ -710,12 +714,12 @@ namespace blueprint
             jassert(ctx);
             ctx->init();
 
-            if (props.contains("onDraw") && props["onDraw"].isMethod())
+            if (props.contains(onDrawProp) && props[onDrawProp].isMethod())
             {
                 std::vector<juce::var> jsArgs {{ctx.get()}};
                 juce::var::NativeFunctionArgs nfArgs (juce::var(), jsArgs.data(), static_cast<int>(jsArgs.size()));
 
-                std::invoke(props["onDraw"].getNativeFunction(), nfArgs);
+                std::invoke(props[onDrawProp].getNativeFunction(), nfArgs);
             }
             else
             {

--- a/blueprint/core/blueprint_ImageView.h
+++ b/blueprint/core/blueprint_ImageView.h
@@ -36,7 +36,8 @@ namespace blueprint
     {
     public:
         //==============================================================================
-        static inline juce::Identifier sourceProp = "source";
+        static inline juce::Identifier sourceProp    = "source";
+        static inline juce::Identifier placementProp = "placement";
 
         //==============================================================================
         ImageView() = default;
@@ -80,14 +81,14 @@ namespace blueprint
         {
             View::paint(g);
 
-            const float opacity = props.getWithDefault("opacity", 1.0f);
+            const float opacity = props.getWithDefault(opacityProp, 1.0f);
 
             // Without a specified placement, we just draw the drawable.
-            if (!props.contains("placement"))
+            if (!props.contains(placementProp))
                 return drawable->draw(g, opacity);
 
             // Otherwise we map placement strings to the appropriate flags
-            const int flags = props["placement"];
+            const int flags = props[placementProp];
             const juce::RectanglePlacement placement (flags);
 
             drawable->drawWithin(g, getLocalBounds().toFloat(), placement, opacity);
@@ -153,7 +154,7 @@ namespace blueprint
             {
                 throw std::runtime_error("Image received an invalid data url.");
             }
-            
+
             const auto base64EncodedData = source.substring(commaIndex + 1);
             juce::MemoryOutputStream outStream{};
 
@@ -166,7 +167,7 @@ namespace blueprint
 
             const auto mimeType = source.substring(5,semiIndex);
             auto fmt = prepareImageFormat(mimeType);
-            
+
             if (fmt == nullptr)
             {
                 throw std::runtime_error("Unsupported format.");
@@ -176,23 +177,23 @@ namespace blueprint
             {
                 throw std::runtime_error("Cannot understand the image.");
             }
-            
+
             inputStream.setPosition(0);
             return fmt->decodeImage(inputStream);
         }
-        
+
         std::unique_ptr<juce::ImageFileFormat> prepareImageFormat(const juce::String& mimeType) const
         {
             if (mimeType == "image/png")
             {
                 return std::make_unique<juce::PNGImageFormat>();
             }
-            
+
             if (mimeType == "image/jpeg")
             {
                 return std::make_unique<juce::JPEGImageFormat>();
             }
-            
+
             if (mimeType == "image/gif")
             {
                 return std::make_unique<juce::GIFImageFormat>();

--- a/blueprint/core/blueprint_ShadowView.h
+++ b/blueprint/core/blueprint_ShadowView.h
@@ -152,6 +152,13 @@ namespace blueprint
     {
     public:
         //==============================================================================
+        static const inline juce::Identifier debugProp          = "debug";
+        static const inline juce::Identifier durationProp       = "duration";
+        static const inline juce::Identifier easingProp         = "easing";
+        static const inline juce::Identifier frameRateProp      = "frameRate";
+        static const inline juce::Identifier layoutAnimatedProp = "layoutAnimated";
+
+        //==============================================================================
         ShadowView(View* _view) : view(_view)
         {
             YGConfigSetUseWebDefaults(YGConfigGetDefault(), true);
@@ -224,25 +231,25 @@ namespace blueprint
         virtual void flushViewLayout()
         {
 #ifdef DEBUG
-            if (props.contains("debug"))
+            if (props.contains(debugProp))
                 YGNodePrint(yogaNode, (YGPrintOptions) (YGPrintOptionsLayout
                                                         | YGPrintOptionsStyle
                                                         | YGPrintOptionsChildren));
 #endif
 
-            if (props.contains("layoutAnimated"))
+            if (props.contains(layoutAnimatedProp))
             {
-                if (props["layoutAnimated"].isBool() && props["layoutAnimated"])
+                if (props[layoutAnimatedProp].isBool() && props[layoutAnimatedProp])
                 {
                     // Default parameters
                     return flushViewLayoutAnimated(50.0, 45, BoundsAnimator::EasingType::Linear);
                 }
 
-                if (props["layoutAnimated"].isObject())
+                if (props[layoutAnimatedProp].isObject())
                 {
-                    double const durationMs = props["layoutAnimated"].getProperty("duration", 50.0);
-                    double const frameRate = props["layoutAnimated"].getProperty("frameRate", 45);
-                    int const et = props["layoutAnimated"].getProperty("easing", 0);
+                    double const durationMs = props[layoutAnimatedProp].getProperty(durationProp, 50.0);
+                    double const frameRate = props[layoutAnimatedProp].getProperty(frameRateProp, 45);
+                    int const et = props[layoutAnimatedProp].getProperty(easingProp, 0);
 
                     return flushViewLayoutAnimated(durationMs, static_cast<int> (frameRate), static_cast<BoundsAnimator::EasingType>(et));
                 }

--- a/blueprint/core/blueprint_TextView.h
+++ b/blueprint/core/blueprint_TextView.h
@@ -23,30 +23,42 @@ namespace blueprint
     {
     public:
         //==============================================================================
+        static const inline juce::Identifier colorProp         = "color";
+
+        static const inline juce::Identifier fontSizeProp      = "font-size";
+        static const inline juce::Identifier fontStyleProp     = "font-style";
+        static const inline juce::Identifier fontFamilyProp    = "font-family";
+
+        static const inline juce::Identifier justificationProp = "justification";
+        static const inline juce::Identifier kerningFactorProp = "kerning-factor";
+        static const inline juce::Identifier lineSpacingProp   = "line-spacing";
+        static const inline juce::Identifier wordWrapProp      = "word-wrap";
+
+        //==============================================================================
         TextView() = default;
 
         //==============================================================================
         /** Assembles a Font from the current node properties. */
         juce::Font getFont()
         {
-            float fontHeight = props.getWithDefault("font-size", 12.0f);
-            int textStyleFlags = props.getWithDefault("font-style", 0);
+            float fontHeight = props.getWithDefault(fontSizeProp, 12.0f);
+            int textStyleFlags = props.getWithDefault(fontStyleProp, 0);
 
             juce::Font f (fontHeight);
 
-            if (props.contains("font-family"))
-                f = juce::Font (props["font-family"], fontHeight, textStyleFlags);
+            if (props.contains(fontFamilyProp))
+                f = juce::Font (props[fontFamilyProp], fontHeight, textStyleFlags);
 
-            f.setExtraKerningFactor(props.getWithDefault("kerning-factor", 0.0));
+            f.setExtraKerningFactor(props.getWithDefault(kerningFactorProp, 0.0));
             return f;
         }
 
         /** Constructs a TextLayout from all the children string values. */
         juce::TextLayout getTextLayout (float maxWidth)
         {
-            juce::String hexColor = props.getWithDefault("color", "ff000000");
+            juce::String hexColor = props.getWithDefault(colorProp, "ff000000");
             juce::Colour colour = juce::Colour::fromString(hexColor);
-            int just = props.getWithDefault("justification", 1);
+            int just = props.getWithDefault(justificationProp, 1);
             juce::String text;
 
             // TODO: Right now a <Text> element maps 1:1 to a TextView instance,
@@ -62,14 +74,14 @@ namespace blueprint
             juce::AttributedString as (text);
             juce::TextLayout tl;
 
-            as.setLineSpacing(props.getWithDefault("line-spacing", 1.0f));
+            as.setLineSpacing(props.getWithDefault(lineSpacingProp, 1.0f));
             as.setFont(getFont());
             as.setColour(colour);
             as.setJustification(just);
 
-            if (props.contains("word-wrap"))
+            if (props.contains(wordWrapProp))
             {
-                int wwValue = props["word-wrap"];
+                int wwValue = props[wordWrapProp];
 
                 switch (wwValue)
                 {

--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -82,7 +82,7 @@ namespace blueprint
     {
         props.set(name, value);
 
-        if (name == juce::StringRef ("interceptClickEvents"))
+        if (name == juce::StringRef (interceptClickEventsProp))
         {
             switch (static_cast<int> (value))
             {
@@ -95,13 +95,13 @@ namespace blueprint
             }
         }
 
-        if (name == juce::StringRef("onKeyPress"))
+        if (name == juce::StringRef(onKeyPressProp))
             setWantsKeyboardFocus(true);
 
-        if (name == juce::StringRef("opacity"))
+        if (name == juce::StringRef(opacityProp))
             setAlpha(static_cast<float> (value));
 
-        if (name == juce::StringRef("refId"))
+        if (name == juce::StringRef(refIdProp))
             _refId = juce::Identifier(value.toString());
     }
 
@@ -113,14 +113,12 @@ namespace blueprint
 
     void View::setFloatBounds(juce::Rectangle<float> bounds)
     {
-        static const juce::Identifier transformMatrix("transform-matrix");
-
         cachedFloatBounds = bounds;
 
         // Update transforms
-        if (props.contains(transformMatrix))
+        if (props.contains(transformMatrixProp))
         {
-            const juce::var& matrix = props[transformMatrix];
+            const juce::var& matrix = props[transformMatrixProp];
             if(matrix.isArray() && matrix.getArray()->size() >= 16) {
               const juce::Array<juce::var> &m = *matrix.getArray();
 
@@ -165,14 +163,14 @@ namespace blueprint
 
     void View::paint (juce::Graphics& g)
     {
-        if (props.contains("border-path"))
+        if (props.contains(borderPathProp))
         {
-            juce::Path p = juce::Drawable::parseSVGPath(props["border-path"].toString());
+            juce::Path p = juce::Drawable::parseSVGPath(props[borderPathProp].toString());
 
-            if (props.contains("border-color"))
+            if (props.contains(borderColorProp))
             {
-                juce::Colour c = juce::Colour::fromString(props["border-color"].toString());
-                float borderWidth = props.getWithDefault("border-width", 1.0);
+                juce::Colour c = juce::Colour::fromString(props[borderColorProp].toString());
+                float borderWidth = props.getWithDefault(borderWidthProp, 1.0);
 
                 g.setColour(c);
                 g.strokePath(p, juce::PathStrokeType(borderWidth));
@@ -180,11 +178,11 @@ namespace blueprint
 
             g.reduceClipRegion(p);
         }
-        else if (props.contains("border-color") && props.contains("border-width"))
+        else if (props.contains(borderColorProp) && props.contains(borderWidthProp))
         {
             juce::Path border;
-            auto c = juce::Colour::fromString(props["border-color"].toString());
-            float borderWidth = props["border-width"];
+            auto c = juce::Colour::fromString(props[borderColorProp].toString());
+            float borderWidth = props[borderWidthProp];
 
             // Note this little bounds trick. When a Path is stroked, the line width extends
             // outwards in both directions from the coordinate line. If the coordinate
@@ -194,7 +192,7 @@ namespace blueprint
             auto width  = borderBounds.getWidth();
             auto height = borderBounds.getHeight();
             auto minLength = std::min(width, height);
-            float borderRadius = getResolvedLengthProperty("border-radius", minLength);
+            float borderRadius = getResolvedLengthProperty(borderRadiusProp.toString(), minLength);
 
             border.addRoundedRectangle(borderBounds, borderRadius);
             g.setColour(c);
@@ -202,9 +200,9 @@ namespace blueprint
             g.reduceClipRegion(border);
         }
 
-        if (props.contains("background-color"))
+        if (props.contains(backgroundColorProp))
         {
-            juce::Colour c = juce::Colour::fromString(props["background-color"].toString());
+            juce::Colour c = juce::Colour::fromString(props[backgroundColorProp].toString());
 
             if (!c.isTransparent())
                 g.fillAll(c);

--- a/blueprint/core/blueprint_View.h
+++ b/blueprint/core/blueprint_View.h
@@ -30,6 +30,20 @@ namespace blueprint
     {
     public:
         //==============================================================================
+        static const inline juce::Identifier interceptClickEventsProp = "interceptClickEvents";
+        static const inline juce::Identifier onKeyPressProp           = "onKeyPress";
+        static const inline juce::Identifier opacityProp              = "opacity";
+        static const inline juce::Identifier refIdProp                = "refId";
+        static const inline juce::Identifier transformMatrixProp      = "transform-matrix";
+
+        static const inline juce::Identifier backgroundColorProp      = "background-color";
+
+        static const inline juce::Identifier borderColorProp          = "border-color";
+        static const inline juce::Identifier borderPathProp           = "border-path";
+        static const inline juce::Identifier borderRadiusProp         = "border-radius";
+        static const inline juce::Identifier borderWidthProp          = "border-width";
+
+        //==============================================================================
         View() = default;
         ~View() override = default;
 


### PR DESCRIPTION
	We've seen that dynamic creation of juce::Identifier instances
	when rendering view and setting properties shows up in profiling
	sessions. This tidies things up to use juce::Identifier as
	advices and initialises view property identifiers statically
	rather than creating Identifier instances from strings at
	runtime.