### PR TITLE
Only call ViewManager::performRootShadowTreeLayout from resetAfterCom…

### DIFF
--- a/blueprint/core/blueprint_ViewManager.cpp
+++ b/blueprint/core/blueprint_ViewManager.cpp
@@ -110,7 +110,6 @@ namespace blueprint
                 if (auto* textShadowView = dynamic_cast<TextShadowView*>(parentShadowView))
                 {
                     textShadowView->markDirty();
-                    performRootShadowTreeLayout();
                 }
 
                 // Then we need to paint, but the RawTextView has no idea how to paint its text,
@@ -144,8 +143,6 @@ namespace blueprint
             parentView->addChild(childView, index);
             parentShadowView->addChild(childShadowView, index);
         }
-
-        performRootShadowTreeLayout();
     }
 
     void ViewManager::removeChild(ViewId parentId, ViewId childId)
@@ -185,8 +182,6 @@ namespace blueprint
             for (auto& id : childIds)
                 shadowViewTable.erase(id);
         }
-
-        performRootShadowTreeLayout();
     }
 
     void ViewManager::enumerateChildViewIds (std::vector<ViewId>& ids, View* v)


### PR DESCRIPTION
…mit hook.

	Following olidacombes excellent performance improvements to the
	ShadowView layout code it appears we had some unnecessary calls
	to performRootShadowTreeLayout in the likes of
	ViewManager::addChild and ViewManager::removeChild. We should
	only need to peform a single root layout pass in the
	reconciler's resetAfterCommit hook and when the
	ReactRootApplicationInstance itself is resized. Removing these
	extra calls results in a massive performance improvement.