### PR TITLE
Remove APVTS dependency from GenericEditor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 .vscode/
 .cache/
+/build
 
 examples/TestRunner/Builds
 

--- a/blueprint/core/blueprint_GenericEditor.h
+++ b/blueprint/core/blueprint_GenericEditor.h
@@ -31,7 +31,7 @@ namespace blueprint
     {
     public:
         //==============================================================================
-        BlueprintGenericEditor (juce::AudioProcessor&, const juce::File&, juce::AudioProcessorValueTreeState* = nullptr);
+        BlueprintGenericEditor (juce::AudioProcessor&, const juce::File&);
         ~BlueprintGenericEditor() override;
 
         //==============================================================================
@@ -60,7 +60,11 @@ namespace blueprint
         AppHarness                            harness;
 
         juce::File                            bundleFile;
-        juce::AudioProcessorValueTreeState*   valueTreeState;
+
+        // We keep a map of the parameter IDs and their associated parameter pointers
+        // to have a quick lookup in beforeBundleEvaluated where lambdas are called
+        // with a param ID 
+        std::map<juce::String, juce::AudioProcessorParameter*> parameters;
 
         //==============================================================================
         // The plugin editor holds an array of parameter value readouts which are

--- a/examples/GainPlugin/PluginProcessor.cpp
+++ b/examples/GainPlugin/PluginProcessor.cpp
@@ -193,7 +193,7 @@ AudioProcessorEditor* GainPluginAudioProcessor::createEditor()
     File sourceDir = File(__FILE__).getParentDirectory();
     File bundle = sourceDir.getChildFile("jsui/build/js/main.js");
 
-    auto* editor = new blueprint::BlueprintGenericEditor(*this, bundle, &params);
+    auto* editor = new blueprint::BlueprintGenericEditor(*this, bundle);
 
     editor->setResizable(true, true);
     editor->setResizeLimits(400, 240, 400 * 2, 240 * 2);


### PR DESCRIPTION
Like we discussed on Discord, I removed the reference to the APVTS in the BlueprintGenericEditor class.

Instead there's a map that links the parameter IDs to their respective parameter pointers, this allows a lookup in the beforeBundleEvaluated method.

The GainPlugin has been modified accordingly and tested, it works like before, I checked in debug mode to ensure we triggered the methods in the lambda functions when moving the knob.

I tried to follow the coding style, don't hesitate to modify anything if needed :)

Cheers!