### PR TITLE
(#116) Avoid __FILE__ directive in gain plugin example and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@
 
 .vscode/
 .cache/
-/build
 
+build
 examples/TestRunner/Builds
+examples/**/build
 
 ._*
 *.mode1v3
@@ -43,7 +44,6 @@ contents.xcworkspacedata
 .dirstamp
 profile
 node_modules
-examples/**/build
 **/MacOSX/build
 **/iOS/build
 **/IDEWorkspaceChecks.plist

--- a/docs/New_Project.md
+++ b/docs/New_Project.md
@@ -99,8 +99,9 @@ public:
     {
         // First thing we have to do is load our javascript bundle from the build
         // directory so that we can evaluate it within our appRot.
-        File sourceDir = File(__FILE__).getParentDirectory();
-        File bundle = sourceDir.getChildFile("jsui/build/js/main.js");
+
+        // TODO: Replace this with the appropriate path to your javascript bundle!
+        File bundle = File("/path/to/your/jsui/build/js/main.js");
 
         addAndMakeVisible(appRoot);
         appRoot.evaluate(bundle);

--- a/examples/GainPlugin/CMakeLists.txt
+++ b/examples/GainPlugin/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(GainPlugin PRIVATE blueprint/)
 # definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
 target_compile_definitions(GainPlugin
     PUBLIC
-    # JUCE_WEB_BROWSER and JUCE_USE_CURL would be on by default, but you might not need them.
+    GAINPLUGIN_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
     JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
     JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_plugin` call
     JUCE_VST3_CAN_REPLACE_VST2=0)

--- a/examples/GainPlugin/PluginProcessor.cpp
+++ b/examples/GainPlugin/PluginProcessor.cpp
@@ -190,7 +190,7 @@ AudioProcessorEditor* GainPluginAudioProcessor::createEditor()
     // if you provide an AudioProcessorValueTreeState, and manage hot reloading
     // of the source bundle. You can always start with the BlueprintGenericEditor
     // then switch to a custom editor when you need more explicit control.
-    File sourceDir = File(__FILE__).getParentDirectory();
+    File sourceDir = File(GAINPLUGIN_SOURCE_DIR);
     File bundle = sourceDir.getChildFile("jsui/build/js/main.js");
 
     auto* editor = new blueprint::BlueprintGenericEditor(*this, bundle);


### PR DESCRIPTION
Per the discussion in #116, I'm proposing here that we avoid `__FILE__` as it seems to have non-standard behavior. Instead, I'm using a preprocessor directive for the GainPlugin example, and I've updated the docs to alert new users that they will need to fill in the correct path to their bundle file.