### PR TITLE
Fix some mac build warnings

### DIFF
--- a/blueprint/blueprint.cpp
+++ b/blueprint/blueprint.cpp
@@ -34,7 +34,6 @@
  #pragma clang diagnostic ignored "-Wshorten-64-to-32"
  #pragma clang diagnostic ignored "-Wshadow-field-in-constructor"
  #pragma clang diagnostic ignored "-Wsign-conversion"
- #pragma clang diagnostic ignored "-Wused-but-marked-unused"
  #pragma clang diagnostic ignored "-Wformat-nonliteral"
  #if __clang_major__ > 10
   #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"

--- a/blueprint/core/blueprint_EcmascriptEngine.cpp
+++ b/blueprint/core/blueprint_EcmascriptEngine.cpp
@@ -39,6 +39,8 @@
  #pragma clang diagnostic ignored "-Wsign-conversion"
  #pragma clang diagnostic ignored "-Wswitch-enum"
  #pragma clang diagnostic ignored "-Wunused-parameter"
+ #pragma clang diagnostic ignored "-Wused-but-marked-unused"
+ #pragma clang diagnostic ignored "-Wformat-nonliteral"
  #if __clang_major__ > 10
   #pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
   #pragma clang diagnostic ignored "-Wimplicit-int-conversion"

--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -13,7 +13,7 @@ namespace blueprint
 
     namespace detail
     {
-        juce::var getMouseEventRelatedTarget(const juce::MouseEvent& e, const blueprint::View& view)
+        static juce::var getMouseEventRelatedTarget(const juce::MouseEvent& e, const blueprint::View& view)
         {
             juce::Component *topParent              = view.getTopLevelComponent();
             const juce::MouseEvent topRelativeEvent = e.getEventRelativeTo(topParent);
@@ -28,7 +28,7 @@ namespace blueprint
         }
 
         /** A little helper for DynamicObject construction. */
-        juce::var makeViewEventObject (const juce::NamedValueSet& props, const blueprint::View& view)
+        static juce::var makeViewEventObject (const juce::NamedValueSet& props, const blueprint::View& view)
         {
             auto* o = new juce::DynamicObject();
 
@@ -43,7 +43,7 @@ namespace blueprint
         }
 
         /** Another little helper for DynamicObject construction. */
-        juce::var makeViewEventObject (const juce::MouseEvent& me, const blueprint::View &view)
+        static juce::var makeViewEventObject (const juce::MouseEvent& me, const blueprint::View &view)
         {
             // TODO: Get all of it!
             return makeViewEventObject({
@@ -56,7 +56,7 @@ namespace blueprint
         }
 
         /** And another little helper for DynamicObject construction. */
-        juce::var makeViewEventObject (const juce::KeyPress& ke, const blueprint::View &view)
+        static juce::var makeViewEventObject (const juce::KeyPress& ke, const blueprint::View &view)
         {
             // TODO: Get all of it!
             return makeViewEventObject({


### PR DESCRIPTION
  Appear to have occured since the EcmascriptEngine pimpl work due to
  change in location of clang warning pragmas. Also fixed a random issue
  I'm seeing in blueprint::View.