### PR TITLE
Improved CSS Color String Support

### DIFF
--- a/examples/GainPlugin/jsui/src/AnimatedFlexBox.js
+++ b/examples/GainPlugin/jsui/src/AnimatedFlexBox.js
@@ -38,7 +38,7 @@ const styles = {
   container: {
     width: "100%",
     height: "100%",
-    backgroundColor: "ff17191f",
+    backgroundColor: "#17191f",
     justifyContent: "flex-start",
     alignContent: "flex-start",
     flexWrap: "wrap",
@@ -54,7 +54,7 @@ const styles = {
     height: 100.0,
     justifyContent: "space-around",
     alignItems: "center",
-    backgroundColor: "ff87898f",
+    backgroundColor: "#87898f",
     margin: 6.0,
     padding: 6.0,
   },

--- a/examples/GainPlugin/jsui/src/App.js
+++ b/examples/GainPlugin/jsui/src/App.js
@@ -14,9 +14,7 @@ function animatedDraw(ctx) {
   let red = Math.sqrt(width / 100) * 255;
   let hex = Math.floor(red).toString(16);
 
-  // TODO: Should update the ctx proxy to convert from javascript hex strings, aka
-  // #ffffaa to juce's Colour::fromString() API which is ffffffaa.
-  ctx.fillStyle = `ff${hex}ffaa`;
+  ctx.fillStyle = `#${hex}ffaa`;
   ctx.fillRect(0, 0, width, 2);
 }
 
@@ -54,11 +52,15 @@ class App extends Component {
     //   </View>
     // );
 
-    const muteBackgroundColor = this.state.muted ? "ff66FDCF" : "ff17191f";
-    const muteTextColor = this.state.muted ? "ff17191f" : "ff66FDCF";
+    const muteBackgroundColor = this.state.muted
+      ? "#66FDCF"
+      : "hsla(162, 97%, 70%, 0)";
+    const muteTextColor = this.state.muted
+      ? "#17191f"
+      : "hsla(162, 97%, 70%, 1)";
 
-    const sliderFillColor = "ff66FDCF";
-    const sliderTrackColor = "ff626262";
+    const sliderFillColor = "#66FDCF";
+    const sliderTrackColor = "#626262";
 
     const logo_url =
       "https://raw.githubusercontent.com/nick-thompson/blueprint/master/examples/GainPlugin/jsui/src/logo.png";
@@ -104,7 +106,8 @@ const styles = {
   container: {
     width: "100%",
     height: "100%",
-    backgroundColor: "ff17191f",
+    backgroundColor:
+      "linear-gradient(45deg, hsla(225, 15%, 11%, 0.3), #17191f 50%)",
     justifyContent: "center",
     alignItems: "center",
   },
@@ -155,7 +158,7 @@ const styles = {
     alignItems: "center",
     borderRadius: 5.0,
     borderWidth: 2.0,
-    borderColor: "ff66FDCF",
+    borderColor: "rgba(102, 253, 207, 1)",
     marginTop: 10,
     minWidth: 30.0,
     minHeight: 30.0,

--- a/examples/GainPlugin/jsui/src/Label.js
+++ b/examples/GainPlugin/jsui/src/Label.js
@@ -51,7 +51,7 @@ class Label extends Component {
 
 const styles = {
   labelText: {
-    color: "ff626262",
+    color: "#626262",
     fontSize: 16.0,
     lineSpacing: 1.6,
   },

--- a/examples/GainPlugin/jsui/src/ParameterToggleButton.js
+++ b/examples/GainPlugin/jsui/src/ParameterToggleButton.js
@@ -25,8 +25,8 @@ class ParameterToggleButton extends Component {
         ? paramState.currentValue
         : 0.0;
 
-    this.defaultBorderColor = "ff66FDCF";
-    this.hoverBorderColor = "ff66CFFD";
+    this.defaultBorderColor = "#66FDCF";
+    this.hoverBorderColor = "#66CFFD";
 
     this.state = {
       defaultValue: initialDefaultValue,

--- a/packages/react-juce/package.json
+++ b/packages/react-juce/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.11.2",
     "camelcase": "^6.2.0",
+    "color-string": "^1.5.4",
     "core-js": "2.6.0",
     "invariant": "^2.2.4",
     "known-css-properties": "^0.20.0",

--- a/packages/react-juce/src/components/Canvas.ts
+++ b/packages/react-juce/src/components/Canvas.ts
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Colors from "../lib/MacroProperties/Colors";
 
 // TODO: Need to explicitly bind this to members?
 export class CanvasRenderingContext {
@@ -18,17 +19,15 @@ export class CanvasRenderingContext {
 
   //================================================================================
   // Properties
-  //
-  // TODO: Once color string prop PR in switch fontStyle/strokeStyle to
-  //       colors.colorStringToAlphaHex(value)
-  //
   // TODO: Support fillStyle/strokeStyle pattern.
   // TODO: Support fillStyle/strokeStyle gradient.
   set fillStyle(value: string) {
+    value = Colors.colorStringToAlphaHex(value);
     this._drawCommands.push(["setFillStyle", value]);
   }
 
   set strokeStyle(value: string) {
+    value = Colors.colorStringToAlphaHex(value);
     this._drawCommands.push(["setStrokeStyle", value]);
   }
 

--- a/packages/react-juce/src/lib/MacroProperties/Colors.ts
+++ b/packages/react-juce/src/lib/MacroProperties/Colors.ts
@@ -1,0 +1,248 @@
+import ColorString from "color-string";
+import ColorNames from "color-name";
+
+const COLOR_PROPERTIES = ["border-color", "background-color", "color"];
+
+const isColorProperty = (propKey: string): boolean => {
+  return COLOR_PROPERTIES.includes(propKey);
+};
+
+const colorStringToAlphaHex = (colorString: string): string => {
+  //From Hex
+  if (colorString.startsWith("#") && colorString.length === 7) {
+    return `ff${colorString}`.replace("#", "");
+  }
+  //From RGB or RGBA
+  else if (colorString.startsWith("rgb")) {
+    const rgbValues = colorString
+      .split("(")[1]
+      .split(")")[0]
+      .replace(/ /g, "")
+      .split(",");
+    const alphaValue =
+      rgbValues.length === 4
+        ? //@ts-ignore
+          percentToHex(100 * rgbValues.pop())
+        : "ff";
+    const hex = rgbValues.map((color) => {
+      const hex = Number.parseInt(color).toString(16);
+      return hex.length == 1 ? "0" + hex : hex;
+    });
+    return alphaValue + hex.join("");
+  }
+  //From HSL or HSLA
+  else if (colorString.startsWith("hsl")) {
+    const hslValues = colorString
+      .split("(")[1]
+      .split(")")[0]
+      .replace(/ |[%]/g, "")
+      .split(",");
+    const alphaValue =
+      hslValues.length === 4
+        ? //@ts-ignore
+          percentToHex(100 * hslValues.pop())
+        : "ff";
+    const hex = hslToHex(
+      Number.parseInt(hslValues[0]),
+      Number.parseInt(hslValues[1]),
+      Number.parseInt(hslValues[2])
+    );
+    return alphaValue + hex;
+  }
+  //From Linear Gradient
+  else if (colorString.startsWith("linear-gradient")) {
+    const lgValues = colorString
+      .split(/\((.+)/)[1]
+      .split(/\)$/)[0]
+      .split(/,+(?![^\(]*\))/)
+      .map((item) => {
+        return item.split(" ");
+      });
+    //concat any arrays that contain hsl or rba strings
+    lgValues.forEach((itemArr, idx) => {
+      if (itemArr.find((item) => item.includes("(")) !== undefined) {
+        const itemArrClone = itemArr.slice();
+        const startIdx = itemArrClone.findIndex((item) => item.includes("("));
+        const endIdx = itemArrClone.findIndex((item) => item.includes(")"));
+        const colorHSLRGB = itemArrClone.slice(startIdx, endIdx + 1).join("");
+        itemArr.splice(startIdx, endIdx + 1, colorHSLRGB);
+        lgValues[idx] = itemArr;
+      } else {
+        lgValues[idx] = itemArr;
+      }
+    });
+    //flatten array
+    const lgValuesCleaned: Array<String> = [].concat
+      // @ts-ignore
+      .apply([], lgValues)
+      .filter((item) => {
+        return item != "";
+      });
+    //converts any colorStrings in linear gradient to alpha-hex
+    let skipCurrentIdx = -1;
+    const lgValuesConverted = lgValuesCleaned
+      .map((value, idx) => {
+        if (skipCurrentIdx == idx) return;
+        // @ts-ignore
+        let convertedColorString = colorStringToAlphaHex(value);
+        //check if the next element is a percent and attach to current and remove it
+        const nextIdx = idx + 1;
+        if (
+          lgValuesCleaned[nextIdx] !== undefined &&
+          lgValuesCleaned[nextIdx].includes("%") &&
+          !lgValuesCleaned[nextIdx].includes("(")
+        ) {
+          convertedColorString += lgValuesCleaned[nextIdx];
+          skipCurrentIdx = nextIdx;
+        }
+        return convertedColorString;
+      })
+      .filter((item) => {
+        return item !== undefined;
+      });
+    return "linear-gradient(" + lgValuesConverted.join(",") + ")";
+  }
+  //From Named Colours
+  else if (Object.keys(ColorNames).includes(colorString)) {
+    const rgbValues = ColorString.get.rgb(colorString);
+    const hex = ColorString.to.hex(rgbValues);
+    return colorStringToAlphaHex(hex);
+  } else {
+    return colorString;
+  }
+};
+
+const convertLinearGradientStringToNativeObject = (
+  lgColorStringHex: string
+): object => {
+  const linearGradientNativeObject = {};
+  const lgValues = lgColorStringHex
+    .split(/\((.+)/)[1]
+    .split(/\)$/)[0]
+    .replace(/ /g, "")
+    .split(/,+(?![^\(]*\))/);
+  //Check for directional words
+  let angle: number = 0;
+  let rotation: string = lgValues[0];
+  if (rotation == "toleft") angle = 270;
+  if (rotation == "toright") angle = 90;
+  if (rotation == "tobottom") angle = 180;
+  if (rotation == "totop") angle = 0;
+
+  //These are not the exact match to CSS as boundary dimensions are required for calculation
+  if (rotation == "totopleft" || rotation == "tolefttop") angle = 295;
+  if (rotation == "totopright" || rotation == "torighttop") angle = 45;
+  if (rotation == "tobottomright" || rotation == "torightbottom") angle = 115;
+  if (rotation == "tobottomleft" || rotation == "toleftbottom") angle = 205;
+
+  //Check for Turns
+  if (rotation.includes("turn")) {
+    rotation = rotation.replace("turn", "");
+    const turns: number = parseFloat(rotation);
+    angle = 360 * turns;
+  }
+  //Check for Degrees
+  if (rotation.includes("deg")) {
+    rotation = rotation.replace("deg", "");
+    angle = parseInt(rotation);
+  }
+
+  linearGradientNativeObject["angle"] = angle;
+  linearGradientNativeObject["colours"] = [];
+  const colorPositions: Array<String> = lgValues.slice(1);
+
+  colorPositions.forEach((colorPos, idx) => {
+    const hexPosObj = { id: idx };
+    const hex = colorPos.slice(0, 8);
+    //check string is an alpha hex
+    const isValidAlphaHex =
+      // @ts-ignore
+      hex.match(
+        /^[0-9a-fA-F]{8}$|#[0-9a-fA-F]{6}$|#[0-9a-fA-F]{4}$|#[0-9a-fA-F]{3}$/
+      ).length > 0;
+    if (!isValidAlphaHex) return;
+    colorPos = colorPos.replace(hex, "");
+    if (colorPos.includes("%")) {
+      colorPos = colorPos.replace("%", "");
+      // @ts-ignore
+      let colorPercent = parseInt(colorPos) / 100;
+      //check if previous percent is greater or equal to the current
+      if (linearGradientNativeObject["colours"].length > 0) {
+        const previousPos =
+          linearGradientNativeObject["colours"][idx - 1]["position"];
+        if (previousPos >= colorPercent) colorPercent = previousPos + 0.001;
+      }
+      hexPosObj["position"] = colorPercent;
+    } else {
+      if (idx == 0) {
+        hexPosObj["position"] = 0.0;
+      } else if (idx == colorPositions.length - 1) {
+        hexPosObj["position"] = 1.0;
+      }
+      //assign null and iterate over again later
+      else {
+        hexPosObj["position"] = undefined;
+      }
+    }
+    hexPosObj["hex"] = hex;
+    linearGradientNativeObject["colours"].push(hexPosObj);
+  });
+  //Find half way between previous and next given percent if no percentage assigned
+  linearGradientNativeObject["colours"].forEach((colorPos, idx) => {
+    if (colorPos["position"] === undefined) {
+      //find next color with percentage
+      const colorsClone = JSON.parse(
+        JSON.stringify(linearGradientNativeObject["colours"])
+      );
+      let currentArrayChunk = colorsClone.splice(idx);
+      const nextColorPercent = currentArrayChunk.find(
+        (colorPos) => colorPos["position"] != undefined && colorPos["id"] !== 0
+      );
+      const nextColorPercentIdx = currentArrayChunk.findIndex(
+        (colorPos) => colorPos["position"] != undefined && colorPos["id"] !== 0
+      );
+      currentArrayChunk = currentArrayChunk.splice(0, nextColorPercentIdx + 1);
+      const previousColorPercent = colorsClone[idx - 1];
+      const y = nextColorPercent["position"];
+      const x = previousColorPercent["position"];
+      const n = currentArrayChunk.length + 1;
+      //assign evenly distributed values to each undefined color in current array chunk
+      currentArrayChunk.forEach((colorPosChunk, idx) => {
+        idx += 1;
+        if (colorPosChunk["position"] === undefined) {
+          const colorPosition = x + ((y - x) / (n - 1)) * idx;
+          const colorPosObj =
+            linearGradientNativeObject["colours"][colorPosChunk["id"]];
+          colorPosObj["position"] = colorPosition;
+        }
+      });
+    }
+  });
+  return linearGradientNativeObject;
+};
+
+const hslToHex = (h: number, s: number, l: number): string => {
+  l /= 100;
+  const a = (s * Math.min(l, 1 - l)) / 100;
+  const f = (n) => {
+    const k = (n + h / 30) % 12;
+    const color = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `${f(0)}${f(8)}${f(4)}`;
+};
+
+const percentToHex = (p: number): string => {
+  p = p > 100 ? 100 : p;
+  const intValue = Math.round((p / 100) * 255);
+  const hexValue = intValue.toString(16);
+  return hexValue.padStart(2, "0").toLowerCase();
+};
+
+export default {
+  isColorProperty,
+  colorStringToAlphaHex,
+  convertLinearGradientStringToNativeObject,
+};

--- a/react_juce/core/Utils.cpp
+++ b/react_juce/core/Utils.cpp
@@ -22,5 +22,152 @@ namespace reactjuce
 
             return o.get();
         }
+
+        std::variant<juce::Colour, juce::ColourGradient> makeColorVariant(const juce::var& colorVariant, const juce::Rectangle<int>& localBounds)
+        {
+            //If object we assume it's a linear gradient
+            if(colorVariant.isObject()) {
+                auto linearGradientObj = juce::JSON::parse(juce::JSON::toString(colorVariant));
+                int deg = linearGradientObj.getProperty("angle", juce::var());
+                double radians = deg * (M_PI/180);
+                auto colorStops = linearGradientObj.getProperty("colours", juce::var()).getArray();
+                double maximumPercent = colorStops->getFirst().getProperty("position", juce::var());
+                double minimumPercent = colorStops->getFirst().getProperty("position", juce::var());
+                juce::DynamicObject::Ptr colorStopsObj = new juce::DynamicObject();
+                juce::Colour maxColor;
+                juce::Colour minColor;
+                for(auto& colorStop : *colorStops) {
+                    double currentPosition = colorStop.getProperty("position", juce::var());
+                    juce::String currentHex = colorStop.getProperty("hex", juce::var());
+                    juce::DynamicObject::Ptr colorStopObj = new juce::DynamicObject();
+                    colorStopObj->setProperty("hex", currentHex);
+                    colorStopObj->setProperty("position", currentPosition);
+                    colorStopObj->setProperty("type", "additional");
+                    juce::String colorUUID = juce::Uuid().toString();
+                    colorStopsObj->setProperty(colorUUID, colorStopObj.get());
+                    if(currentPosition >= maximumPercent) {
+                        maximumPercent = currentPosition;
+                        for (auto& colors : colorStopsObj->getProperties())
+                        {
+                            juce::String colorID = colors.name.toString();
+                            auto* color = colorStopsObj->getProperty(colorID).getDynamicObject();
+                            if(color->getProperty("type") == "max"){
+                                color->setProperty("type", "additional");
+                            }
+                        }
+                        juce::String hexString = colorStopObj->getProperty("hex");
+                        maxColor = juce::Colour::fromString(hexString);
+                        colorStopObj->setProperty("type", "max");
+                    }
+                    if(currentPosition <= minimumPercent) {
+                        minimumPercent = currentPosition;
+                        for (auto& colors : colorStopsObj->getProperties())
+                        {
+                            juce::String colorID = colors.name.toString();
+                            auto* color = colorStopsObj->getProperty(colorID).getDynamicObject();
+                            if(color->getProperty("type") == "min"){
+                                color->setProperty("type", "additional");
+                            }
+                        }
+                        juce::String hexString = colorStopObj->getProperty("hex");
+                        minColor = juce::Colour::fromString(hexString);
+                        colorStopObj->setProperty("type", "min");
+                    }
+                }
+                double positiveExtensionPercent = maximumPercent - 1.0;
+                double negativeExtensionPercent = minimumPercent * -1;
+                juce::Rectangle <int> const b {localBounds};
+                int x1; int x2; int y1; int y2;
+                int width = b.getWidth();
+                int height = b.getHeight();
+                juce::Array<int> centerPoint{width/2, height/2};
+                auto getEdgePointsFromAngle = [](int width, int height, int deg){
+                    double twoPI = M_PI * 2;
+                    double theta = (360 - (deg + 270))  * M_PI / 180;
+                    while (theta < -M_PI) {
+                        theta += twoPI;
+                    }
+                    while (theta > M_PI) {
+                        theta -= twoPI;
+                    }
+                    double rectAtan = atan2(height, width);
+                    double tanTheta = tan(theta);
+                    int region;
+                    if ((theta > -rectAtan) && (theta <= rectAtan)) {
+                        region = 1;
+                    } else if ((theta > rectAtan) && (theta <= (M_PI - rectAtan))) {
+                        region = 2;
+                    } else if ((theta > (M_PI - rectAtan)) || (theta <= -(M_PI - rectAtan))) {
+                        region = 3;
+                    } else {
+                        region = 4;
+                    }
+                    double xEdge = width / 2;
+                    double yEdge = height / 2;
+                    int xFactor = 1;
+                    int yFactor = 1;
+
+                    switch(region) {
+                        case 1: yFactor = -1; break;
+                        case 2: yFactor = -1; break;
+                        case 3: xFactor = -1; break;
+                        case 4: xFactor = -1; break;
+                    }
+
+                    if ((region == 1) || (region == 3)) {
+                        xEdge += xFactor * (width / 2.);
+                        yEdge += yFactor * (width / 2.) * tanTheta;
+                    }
+                    else {
+                        xEdge += xFactor * (height / (2. * tanTheta));
+                        yEdge += yFactor * (height /  2.);
+                    }
+                    juce::Array<int> edgePoints{xEdge, yEdge};
+                    return edgePoints;
+                };
+                //Calculate the gradient Line End point coordinates
+                juce::Array<int> edgePoint1 = getEdgePointsFromAngle(width, height, deg + 180);
+                x1 = edgePoint1[0]; y1 = edgePoint1[1];
+                juce::Array<int> edgePoint2 = getEdgePointsFromAngle(width, height, deg);
+                x2 = edgePoint2[0]; y2 = edgePoint2[1];
+                double gradientLineDistance = abs(b.getWidth() * sin(radians) + abs(b.getHeight() * cos(radians)));
+                double edgePoint1CenterDist = sqrt(pow((x1 - centerPoint[0]), 2) + pow((y1 - centerPoint[1]), 2));
+                double edgePoint2CenterDist = sqrt(pow((x2 - centerPoint[0]), 2) + pow((y2 - centerPoint[1]), 2));
+                double halfGradientDistance = gradientLineDistance/2;
+                double distanceRatio1 = halfGradientDistance/edgePoint1CenterDist;
+                double distanceRatio2 = halfGradientDistance/edgePoint2CenterDist;
+                x1 = ((1 - distanceRatio1) * centerPoint[0]) + (distanceRatio1 * x1);
+                y1 = ((1 - distanceRatio1) * centerPoint[1]) + (distanceRatio1 * y1);
+                x2 = ((1 - distanceRatio2) * centerPoint[0]) + (distanceRatio2 * x2);
+                y2 = ((1 - distanceRatio2) * centerPoint[1]) + (distanceRatio2 * y2);
+                //Gradient line Points
+                int glX1 = x1; int glX2 = x2; int glY1 = y1; int glY2 = y2;
+                //Offset the gradient line length with min max extension percent
+                x1 = ((1 - (negativeExtensionPercent * -1)) * glX1) + ((negativeExtensionPercent * -1) * glX2);
+                y1 = ((1 - (negativeExtensionPercent * -1)) * glY1) + ((negativeExtensionPercent * -1) * glY2);
+                x2 = ((1 - (positiveExtensionPercent * -1)) * glX2) + ((positiveExtensionPercent * -1) * glX1);
+                y2 = ((1 - (positiveExtensionPercent * -1)) * glY2) + ((positiveExtensionPercent * -1) * glY1);
+                juce::ColourGradient gradient = juce::ColourGradient (minColor, x1, y1, maxColor, x2, y2,false);
+                for (auto& colors : colorStopsObj->getProperties())
+                {
+                    juce::String colorID = colors.name.toString();
+                    auto* color = colorStopsObj->getProperty(colorID).getDynamicObject();
+                    //Calculate any offset from the original additional color percentage along gradient line
+                    if(color->getProperty("type") == "additional"){
+                        juce::String hexString = color->getProperty("hex");
+                        juce::Colour additionalColor = juce::Colour::fromString(hexString);
+                        double originalPercent = color->getProperty("position");
+                        double gradientLineDistanceExtension = gradientLineDistance * (1 + (negativeExtensionPercent + positiveExtensionPercent));
+                        double offsetPercent = ((gradientLineDistance * originalPercent) + (gradientLineDistance * negativeExtensionPercent)) / gradientLineDistanceExtension;
+                        gradient.addColour(offsetPercent, additionalColor);
+                    }
+                }
+                return gradient;
+            }
+            //else we assume it's just one colour
+            else {
+                return juce::Colour::fromString(colorVariant.toString());;
+            }
+        }
     }
 }

--- a/react_juce/core/Utils.h
+++ b/react_juce/core/Utils.h
@@ -8,6 +8,7 @@
 */
 
 #pragma once
+#include <variant>
 
 namespace reactjuce
 {
@@ -15,5 +16,8 @@ namespace reactjuce
     {
         // Constructs a generic error object to pass through to JS
         juce::var makeErrorObject(const juce::String& errorName, const juce::String& errorMessage);
+
+        // Constructs either a Color or ColorGradient
+        std::variant<juce::Colour, juce::ColourGradient> makeColorVariant(const juce::var& colorVariant, const juce::Rectangle<int>& localBounds);
     }
 }

--- a/react_juce/core/View.cpp
+++ b/react_juce/core/View.cpp
@@ -8,6 +8,7 @@
 */
 
 #include "View.h"
+#include "Utils.h"
 
 
 namespace reactjuce
@@ -171,7 +172,8 @@ namespace reactjuce
 
             if (props.contains(borderColorProp))
             {
-                juce::Colour c = juce::Colour::fromString(props[borderColorProp].toString());
+                juce::StringRef colorString = props[borderColorProp].toString();
+                juce::Colour c = juce::Colour::fromString(colorString);
                 float borderWidth = props.getWithDefault(borderWidthProp, 1.0);
 
                 g.setColour(c);
@@ -183,7 +185,8 @@ namespace reactjuce
         else if (props.contains(borderColorProp) && props.contains(borderWidthProp))
         {
             juce::Path border;
-            auto c = juce::Colour::fromString(props[borderColorProp].toString());
+            juce::StringRef colorString = props[borderColorProp].toString();
+            auto c = juce::Colour::fromString(colorString);
             float borderWidth = props[borderWidthProp];
 
             // Note this little bounds trick. When a Path is stroked, the line width extends
@@ -204,10 +207,18 @@ namespace reactjuce
 
         if (props.contains(backgroundColorProp))
         {
-            juce::Colour c = juce::Colour::fromString(props[backgroundColorProp].toString());
-
-            if (!c.isTransparent())
-                g.fillAll(c);
+            auto colorProp = props[backgroundColorProp];
+            auto colorVariant = detail::makeColorVariant(colorProp, getLocalBounds());
+            if(const auto color (std::get_if<juce::Colour>(&colorVariant)); color)
+            {
+                if (!color->isTransparent())
+                    g.fillAll(*color);
+            }
+            else if(const auto gradient (std::get_if<juce::ColourGradient>(&colorVariant)); gradient)
+            {
+                g.setGradientFill(*gradient);
+                g.fillAll();
+            }
         }
     }
 


### PR DESCRIPTION
Added css styled color string support addressing #84 
It includes:

- Hex Colors
- RGB & RGBA
- HSL & HSLA
- JUCE's named colors
- Basic linear gradients.

linear gradient functionality includes:

- Two colors
- Supporting any variation mix of css colors I.E hex, hsl, rgb, etc
- Directional words. I.E to left, to bottom right etc
- Degrees I.E 45deg, 180deg

I've also updated the Gain plugin with some examples with most of the color variations so users can see how to use the colors.
Anyway let me know if you guys have any questions or thoughts!