### PR TITLE
First pass v8 integration

### DIFF
--- a/examples/GainPlugin/CMakeLists.txt
+++ b/examples/GainPlugin/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 project(GainPlugin VERSION 0.1.0)
 
+# Apparently this has to come before any `add_executable` calls
+link_directories(~/Dev/v8/v8/out.gn/x64.release.sample/obj/)
+
 # `juce_add_plugin` adds a static library target with the name passed as the first argument.
 # This target is a normal CMake target, but has a lot of extra properties set
 # up by default. As well as this shared code static library, this function adds targets for each of
@@ -39,7 +42,7 @@ target_sources(GainPlugin PRIVATE PluginProcessor.cpp)
 # Add an explicit include path here so that Blueprint's EcmascriptEngine can find
 # the included Duktape source. You can optionally point this elsewhere if you'd like to
 # include a custom Duktape build.
-target_include_directories(GainPlugin PRIVATE react_juce/)
+target_include_directories(GainPlugin PRIVATE react_juce/ ~/Dev/v8/v8/include/)
 
 # `target_compile_definitions` adds some preprocessor definitions to our target. In a Projucer
 # project, these might be passed in the 'Preprocessor Definitions' field. JUCE modules also make use
@@ -49,6 +52,8 @@ target_include_directories(GainPlugin PRIVATE react_juce/)
 # definitions, pick unique names that are unlikely to collide! This is a standard CMake command.
 target_compile_definitions(GainPlugin
     PUBLIC
+    REACTJUCE_USE_V8=1
+    V8_COMPRESS_POINTERS=1
     GAINPLUGIN_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
     JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
     JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_plugin` call
@@ -70,4 +75,5 @@ target_link_libraries(GainPlugin PRIVATE
     juce::juce_audio_utils
     juce::juce_graphics
     juce::juce_gui_basics
-    react_juce)
+    react_juce
+    v8_monolith)

--- a/react_juce/core/EcmascriptEngine_v8.cpp
+++ b/react_juce/core/EcmascriptEngine_v8.cpp
@@ -1,0 +1,181 @@
+/*
+  ==============================================================================
+
+    blueprint_EcmascriptEngine.cpp
+    Created: 24 Oct 2019 3:08:39pm
+
+  ==============================================================================
+*/
+
+#include "EcmascriptEngine.h"
+
+#include <libplatform/libplatform.h>
+#include <v8.h>
+
+
+namespace blueprint
+{
+
+    //==============================================================================
+    struct EcmascriptEngine::Pimpl
+    {
+        Pimpl() = default;
+        ~Pimpl() = default;
+
+        //==============================================================================
+        juce::var evaluate (const juce::File& code)
+        {
+            jassert(code.existsAsFile());
+            jassert(code.loadFileAsString().isNotEmpty());
+
+            // Initialize V8.
+            v8::V8::InitializeICUDefaultLocation("/Users/nick/Dev/v8/v8/hello_world");
+            v8::V8::InitializeExternalStartupData("/Users/nick/Dev/v8/v8/hello_world");
+            std::unique_ptr<v8::Platform> platform = v8::platform::NewDefaultPlatform();
+            v8::V8::InitializePlatform(platform.get());
+            v8::V8::Initialize();
+
+            // Create a new Isolate and make it the current one.
+            v8::Isolate::CreateParams create_params;
+            create_params.array_buffer_allocator = v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+            v8::Isolate* isolate = v8::Isolate::New(create_params);
+
+            {
+                v8::Isolate::Scope isolate_scope(isolate);
+
+                // Create a stack-allocated handle scope.
+                v8::HandleScope handle_scope(isolate);
+
+                // Create a new context.
+                v8::Local<v8::Context> context = v8::Context::New(isolate);
+
+                // Create an empty object representing __BlueprintNative__
+                v8::Local<v8::ObjectTemplate> emptyTempl = v8::ObjectTemplate::New(isolate);
+                v8::Local<v8::Object> native = emptyTempl->NewInstance(context).ToLocalChecked();
+
+                native->Set(
+                    context,
+                    v8::String::NewFromUtf8(isolate, "getRootInstanceId").ToLocalChecked(),
+                    v8::Function::New(context, [](const v8::FunctionCallbackInfo<v8::Value>& args) {
+                        if (args.Length() >= 1)
+                        {
+                            auto* isolate = args.GetIsolate();
+                            v8::HandleScope scope(isolate);
+                            v8::Local<v8::Value> arg = args[0];
+                            v8::String::Utf8Value value(isolate, arg);
+                            DBG(*value);
+                        }
+                        args.GetReturnValue().Set(1);
+                    }).ToLocalChecked()
+                );
+
+                context->Global()->Set(
+                    context,
+                    v8::String::NewFromUtf8(isolate, "__BlueprintNative__").ToLocalChecked(),
+                    native
+                );
+
+                context->Global()->Set(
+                    context,
+                    v8::String::NewFromUtf8(isolate, "setTimeout").ToLocalChecked(),
+                    v8::Function::New(context, [](const v8::FunctionCallbackInfo<v8::Value>& args) {
+                        DBG("setTimeout called");
+                    }).ToLocalChecked()
+                );
+
+                // Enter the context for compiling and running the hello world script.
+                v8::Context::Scope context_scope(context);
+
+                {
+                    // Create a string containing the JavaScript source code.
+                    v8::Local<v8::String> source =
+                        v8::String::NewFromUtf8(isolate, code.loadFileAsString().toRawUTF8(),
+                                v8::NewStringType::kNormal)
+                        .ToLocalChecked();
+
+                    // Compile the source code.
+                    v8::Local<v8::Script> script =
+                        v8::Script::Compile(context, source).ToLocalChecked();
+
+                    // Run the script to get the result.
+                    v8::Local<v8::Value> result = script->Run(context).ToLocalChecked();
+
+                    // Convert the result to an UTF8 string and print it.
+                    v8::String::Utf8Value utf8(isolate, result);
+                    printf("%s\n", *utf8);
+                }
+            }
+
+            // Dispose the isolate and tear down V8.
+            isolate->Dispose();
+            v8::V8::Dispose();
+            v8::V8::ShutdownPlatform();
+            delete create_params.array_buffer_allocator;
+
+            return juce::var("TODO");
+        }
+    };
+
+    //==============================================================================
+    EcmascriptEngine::EcmascriptEngine()
+        : mPimpl(std::make_unique<Pimpl>())
+    {
+        /** If you hit this, you're probably trying to run a console application.
+
+            Please make use of juce::ScopedJuceInitialiser_GUI because this JS engine requires event loops.
+            Without the initialiser, the console app would always crash on exit,
+            and things will probably not get cleaned up.
+        */
+        jassert (juce::MessageManager::getInstanceWithoutCreating() != nullptr);
+    }
+
+    EcmascriptEngine::~EcmascriptEngine() = default;
+
+    //==============================================================================
+    juce::var EcmascriptEngine::evaluateInline (const juce::String& code)
+    {
+        return juce::var("Not Implemented.");
+    }
+
+    juce::var EcmascriptEngine::evaluate (const juce::File& code)
+    {
+        return mPimpl->evaluate(code);
+    }
+
+    //==============================================================================
+    void EcmascriptEngine::registerNativeMethod (const juce::String& name, juce::var::NativeFunction fn)
+    {
+        registerNativeProperty(name, juce::var(fn));
+    }
+
+    void EcmascriptEngine::registerNativeMethod (const juce::String& target, const juce::String& name, juce::var::NativeFunction fn)
+    {
+        registerNativeProperty(target, name, juce::var(fn));
+    }
+
+    //==============================================================================
+    void EcmascriptEngine::registerNativeProperty (const juce::String& name, const juce::var& value)
+    {
+        juce::ignoreUnused(name);
+        juce::ignoreUnused(value);
+    }
+
+    void EcmascriptEngine::registerNativeProperty (const juce::String& target, const juce::String& name, const juce::var& value)
+    {
+        juce::ignoreUnused(name);
+        juce::ignoreUnused(value);
+    }
+
+    //==============================================================================
+    juce::var EcmascriptEngine::invoke (const juce::String& name, const std::vector<juce::var>& vargs)
+    {
+        return juce::var("Not Implemented");
+    }
+
+    void EcmascriptEngine::reset() {}
+
+    //==============================================================================
+    void EcmascriptEngine::debuggerAttach() {}
+    void EcmascriptEngine::debuggerDetach() {}
+
+}

--- a/react_juce/react_juce.cpp
+++ b/react_juce/react_juce.cpp
@@ -75,7 +75,12 @@
 #endif
 
 #include "core/AppHarness.cpp"
+
+#ifdef REACTJUCE_USE_V8
+#include "core/EcmascriptEngine_v8.cpp"
+#else
 #include "core/EcmascriptEngine.cpp"
+#endif
 
 #if JUCE_MODULE_AVAILABLE_juce_audio_processors
     #include "core/GenericEditor.cpp"


### PR DESCRIPTION
A'ight @JoshMarler this one's for you!

This work is _not_ a branch I intend to merge, at least not in its current state. This is more of a proof-of-concept branch for kicking off the v8 integration behind the EcmascriptEngine interface (#178).

The work here addresses only this:
* Linking the GainPlugin against v8 somewhere external to the project. You can see that I have v8 in `~/Dev/v8/v8`, and have built a macos x64 v8_monolith myself for linking.
* Adding a `REACTJUCE_USE_V8` compiler definition for toggling whether to load the Duktape implementation or the V8 implementation, and enabling that def in GainPlugin
* Filling in junk to satisfy the EcmascriptEngine interface in most cases. This essentially has the GainPlugin totally broken, but my goal was to (1) get something compiling and (2) get the first `evaluate` pass to run successfully.

This is almost there. There is a little more work to satisfy some global shims. The first, which I'll add here shortly, is to shim out more of the __BlueprintBackend__ interface, for which I have a clean approach in mind. The second, is adding polyfills for timers to satisfy the updated React-Reconciler dependency.

Then, of course, there's work to actually persist the v8 isolate and context on the `EcmascriptEngine::Pimpl` instance (right now I just make the and throw them away inside of evaluate), and start fleshing out the remainder of the interface. My hunch right now is that this will generally be an easier integration than Duktape, which is quite nice!