### PR TITLE
Add TextInput component

### DIFF
--- a/packages/react-juce/src/components/TextInput.tsx
+++ b/packages/react-juce/src/components/TextInput.tsx
@@ -1,63 +1,59 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren } from "react";
 
 export interface InputEvent {
-  value: string
+  value: string;
 }
 
 export interface ChangeEvent {
-  value: string
+  value: string;
 }
 
 export interface TextInputProps {
-  value?: string,
+  value?: string;
 
-  color?: string,
-  fontSize?: number,
-  fontStyle?: number,
-  fontFamily?: string,
-  justification?: number,
-  'kerning-factor'?: number,
+  color?: string;
+  fontSize?: number;
+  fontStyle?: number;
+  fontFamily?: string;
+  justification?: number;
+  "kerning-factor"?: number;
 
-  placeholder?: string,
-  'placeholder-color'?: string,
-  maxlength?: number,
-  readonly?: boolean,
-  'outline-color'?: string,
-  'focused-outline-color'?: string,
-  'highlighted-text-color'?: string,
-  'highlight-color'?: string,
-  'caret-color'?: string,
+  placeholder?: string;
+  "placeholder-color"?: string;
+  maxlength?: number;
+  readonly?: boolean;
+  "outline-color"?: string;
+  "focused-outline-color"?: string;
+  "highlighted-text-color"?: string;
+  "highlight-color"?: string;
+  "caret-color"?: string;
 
-  onChange?: (e: ChangeEvent) => void,
-  onInput?: (e: InputEvent) => void,
+  onChange?: (e: ChangeEvent) => void;
+  onInput?: (e: InputEvent) => void;
 }
 
 /**
-* TextInput component imitates web's `<input type="text">`.
-* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
-* So it supports props like `placeholder`, `maxlength`, `onInput`, etc...
-* 
-* TextInput also supports React's controlled components model:
-* https://reactjs.org/docs/uncontrolled-components.html.
-* If the user supplies a `value` prop,
-* then it never renders anything into that text editor other than
-* the string supplied by that `value` prop.
-*/
+ * TextInput component imitates web's `<input type="text">`.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
+ * So it supports props like `placeholder`, `maxlength`, `onInput`, etc...
+ *
+ * TextInput also supports React's controlled components model:
+ * https://reactjs.org/docs/uncontrolled-components.html.
+ * If the user supplies a `value` prop,
+ * then it never renders anything into that text editor other than
+ * the string supplied by that `value` prop.
+ */
 export function TextInput(props: PropsWithChildren<TextInputProps | any>) {
-  return React.createElement('TextInput', props, props.children);
+  return React.createElement("TextInput", props, props.children);
 }
 
 /*
 // ================================================
 // Example code
 
-import React, { Component } from 'react';
+import React, { Component } from "react";
 
-import {
-  Text,
-  TextInput,
-  View,
-} from 'react-juce';
+import { Text, TextInput, View } from "react-juce";
 
 class App extends Component {
   constructor(props) {
@@ -65,24 +61,24 @@ class App extends Component {
     this._onInput = this._onInput.bind(this);
 
     this.state = {
-      textValue: '',
-    }
+      textValue: "",
+    };
   }
 
   _onInput(event) {
     console.log(`onInput: ${event.value}`);
-    this.setState({textValue: event.value});
+    this.setState({ textValue: event.value });
   }
 
   render() {
     return (
       <View>
         <TextInput
-            value={this.state.textValue}
-            placeholder="init message"
-            onInput={this._onInput}
-            {...styles.text_input}
-          />
+          value={this.state.textValue}
+          placeholder="init message"
+          onInput={this._onInput}
+          {...styles.text_input}
+        />
       </View>
     );
   }
@@ -90,15 +86,15 @@ class App extends Component {
 
 const styles = {
   text_input: {
-    backgroundColor: 'ff303030',
-    color: 'ff66FDCF',
+    backgroundColor: "ff303030",
+    color: "ff66FDCF",
     fontSize: 15.0,
-    fontFamily: 'Menlo',
+    fontFamily: "Menlo",
     fontStyle: Text.FontStyleFlags.bold,
-    'placeholder-color': 'ffaaaaaa',
+    "placeholder-color": "ffAAAAAA",
     height: 30,
     width: 200,
-  }
+  },
 };
 
 export default App;

--- a/packages/react-juce/src/components/TextInput.tsx
+++ b/packages/react-juce/src/components/TextInput.tsx
@@ -1,0 +1,107 @@
+import React, { PropsWithChildren } from 'react';
+
+export interface InputEvent {
+  value: string
+}
+
+export interface ChangeEvent {
+  value: string
+}
+
+export interface TextInputProps {
+  value?: string,
+
+  color?: string,
+  fontSize?: number,
+  fontStyle?: number,
+  fontFamily?: string,
+  justification?: number,
+  'kerning-factor'?: number,
+
+  placeholder?: string,
+  'placeholder-color'?: string,
+  maxlength?: number,
+  readonly?: boolean,
+  'outline-color'?: string,
+  'focused-outline-color'?: string,
+  'highlighted-text-color'?: string,
+  'highlight-color'?: string,
+  'caret-color'?: string,
+
+  onChange?: (e: ChangeEvent) => void,
+  onInput?: (e: InputEvent) => void,
+}
+
+/**
+* TextInput component imitates web's `<input type="text">`.
+* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
+* So it supports props like `placeholder`, `maxlength`, `onInput`, etc...
+* 
+* TextInput also supports React's controlled components model:
+* https://reactjs.org/docs/uncontrolled-components.html.
+* If the user supplies a `value` prop,
+* then it never renders anything into that text editor other than
+* the string supplied by that `value` prop.
+*/
+export function TextInput(props: PropsWithChildren<TextInputProps | any>) {
+  return React.createElement('TextInput', props, props.children);
+}
+
+/*
+// ================================================
+// Example code
+
+import React, { Component } from 'react';
+
+import {
+  Text,
+  TextInput,
+  View,
+} from 'react-juce';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    this._onInput = this._onInput.bind(this);
+
+    this.state = {
+      textValue: '',
+    }
+  }
+
+  _onInput(event) {
+    console.log(`onInput: ${event.value}`);
+    this.setState({textValue: event.value});
+  }
+
+  render() {
+    return (
+      <View>
+        <TextInput
+            value={this.state.textValue}
+            placeholder="init message"
+            onInput={this._onInput}
+            {...styles.text_input}
+          />
+      </View>
+    );
+  }
+}
+
+const styles = {
+  text_input: {
+    backgroundColor: 'ff303030',
+    color: 'ff66FDCF',
+    fontSize: 15.0,
+    fontFamily: 'Menlo',
+    fontStyle: Text.FontStyleFlags.bold,
+    'placeholder-color': 'ffaaaaaa',
+    height: 30,
+    width: 200,
+  }
+};
+
+export default App;
+
+// ================================================
+*/

--- a/packages/react-juce/src/index.tsx
+++ b/packages/react-juce/src/index.tsx
@@ -11,6 +11,7 @@ export * from "./components/View";
 export * from "./components/ScrollView";
 export * from "./components/Canvas";
 export * from "./components/Text";
+export * from "./components/TextInput";
 export * from "./components/Image";
 export * from "./components/Button";
 export * from "./components/Slider";

--- a/react_juce/core/TextInputView.cpp
+++ b/react_juce/core/TextInputView.cpp
@@ -29,31 +29,31 @@ namespace blueprint
         }
     }
 
-    void TextInput::setControlledValue(const juce::String &value)
+    void TextInputView::TextInput::setControlledValue(const juce::String &value)
     {
         insertedAsControlledValue = true;
         setText(value);
     }
 
-    void TextInput::setMaxLength(int maxLen)
+    void TextInputView::TextInput::setMaxLength(int maxLen)
     {
         maxLength = maxLen;
         setInputRestrictions(maxLen);
     }
 
-    void TextInput::setPlaceholderText(const juce::String &text)
+    void TextInputView::TextInput::setPlaceholderText(const juce::String &text)
     {
         placeholderText = text;
         setTextToShowWhenEmpty(placeholderText, placeholderColour);
     }
 
-    void TextInput::setPlaceholderColour(const juce::Colour &colourToUse)
+    void TextInputView::TextInput::setPlaceholderColour(const juce::Colour &colourToUse)
     {
         placeholderColour = colourToUse;
         setTextToShowWhenEmpty(placeholderText, placeholderColour);
     }
 
-    void TextInput::insertTextAtCaret(const juce::String &textToInsert)
+    void TextInputView::TextInput::insertTextAtCaret(const juce::String &textToInsert)
     {
         const juce::String currentValue = getText();
         juce::TextEditor::insertTextAtCaret(textToInsert);
@@ -82,17 +82,17 @@ namespace blueprint
 
     //==============================================================================
 
-    void TextInput::textEditorReturnKeyPressed(juce::TextEditor &)
+    void TextInputView::TextInput::textEditorReturnKeyPressed(juce::TextEditor &)
     {
         invokeChangeEventIfNeeded();
     }
 
-    void TextInput::textEditorFocusLost(juce::TextEditor &)
+    void TextInputView::TextInput::textEditorFocusLost(juce::TextEditor &)
     {
         invokeChangeEventIfNeeded();
     }
 
-    void TextInput::invokeChangeEventIfNeeded()
+    void TextInputView::TextInput::invokeChangeEventIfNeeded()
     {
         if (dirty)
         {

--- a/react_juce/core/TextInputView.cpp
+++ b/react_juce/core/TextInputView.cpp
@@ -64,11 +64,11 @@ namespace blueprint
         }
 
         // Invoke JavaScript's `input` event.
-        if ((*props).contains(TextInputView::onInputProp) && (*props)[TextInputView::onInputProp].isMethod())
+        if (props.contains(TextInputView::onInputProp) && props[TextInputView::onInputProp].isMethod())
         {
             std::array<juce::var, 1> args{{detail::makeInputEventObject(newValue)}};
             juce::var::NativeFunctionArgs nfArgs(juce::var(), args.data(), static_cast<int>(args.size()));
-            std::invoke((*props)[TextInputView::onInputProp].getNativeFunction(), nfArgs);
+            std::invoke(props[TextInputView::onInputProp].getNativeFunction(), nfArgs);
         }
 
         dirty = true;
@@ -97,11 +97,11 @@ namespace blueprint
         if (dirty)
         {
             // Invoke JavaScript's `change` event.
-            if ((*props).contains(TextInputView::onChangeProp) && (*props)[TextInputView::onChangeProp].isMethod())
+            if (props.contains(TextInputView::onChangeProp) && props[TextInputView::onChangeProp].isMethod())
             {
                 std::array<juce::var, 1> args{{detail::makeChangeEventObject(getText())}};
                 juce::var::NativeFunctionArgs nfArgs(juce::var(), args.data(), static_cast<int>(args.size()));
-                std::invoke((*props)[TextInputView::onChangeProp].getNativeFunction(), nfArgs);
+                std::invoke(props[TextInputView::onChangeProp].getNativeFunction(), nfArgs);
             }
             dirty = false;
         }
@@ -110,7 +110,7 @@ namespace blueprint
     //==============================================================================
 
     TextInputView::TextInputView()
-        : textInput(&props)
+        : textInput(props)
     {
         addAndMakeVisible(textInput);
         textInput.addListener(&textInput);
@@ -158,7 +158,7 @@ namespace blueprint
         juce::Colour colour = juce::Colour::fromString(hexColor);
         textInput.applyColourToAllText(colour);
 
-        int just = props.getWithDefault(justificationProp, 1);
+        const int just = props.getWithDefault(justificationProp, 1);
         textInput.setJustification(just);
 
         juce::String hexBackgroundColor = props.getWithDefault(backgroundColorProp, "00000000");
@@ -207,15 +207,10 @@ namespace blueprint
         }
     }
 
-    void TextInputView::paint(juce::Graphics &g)
-    {
-        View::paint(g);
-    }
-
     void TextInputView::resized()
     {
         View::resized();
-        textInput.setBounds(0, 0, getWidth(), getHeight());
+        textInput.setBounds(getLocalBounds());
     }
 
     juce::Font TextInputView::getFont()

--- a/react_juce/core/TextInputView.cpp
+++ b/react_juce/core/TextInputView.cpp
@@ -55,9 +55,9 @@ namespace blueprint
 
     void TextInput::insertTextAtCaret(const juce::String &textToInsert)
     {
-        juce::String currentValue = getText();
+        const juce::String currentValue = getText();
         juce::TextEditor::insertTextAtCaret(textToInsert);
-        juce::String newValue = getText();
+        const juce::String newValue = getText();
         if (currentValue == newValue)
         {
             return;
@@ -109,14 +109,6 @@ namespace blueprint
 
     //==============================================================================
 
-    TextInputView::TextInputView()
-        : textInput(props)
-    {
-        addAndMakeVisible(textInput);
-        textInput.addListener(&textInput);
-        textInput.setPopupMenuEnabled(false);
-    }
-
     void TextInputView::setProperty(const juce::Identifier &name, const juce::var &value)
     {
         View::setProperty(name, value);
@@ -124,29 +116,37 @@ namespace blueprint
         {
             if (!value.isString())
                 throw std::invalid_argument("Invalid prop value. Prop \'value\' must be a string.");
+
             textInput.setControlled(true);
             textInput.setControlledValue(value);
         }
+
         if (name == placeholderProp)
         {
             if (!value.isString())
                 throw std::invalid_argument("Invalid prop value. Prop \'placeholder\' must be a string.");
+
             textInput.setPlaceholderText(value);
         }
+
         if (name == placeholderColorProp)
         {
             if (!value.isString())
                 throw std::invalid_argument("Invalid prop value. Prop \'placeholder-color\' must be a color string.");
-            juce::String hexPlaceholderColor = value;
-            juce::Colour placeholderColor = juce::Colour::fromString(hexPlaceholderColor);
+
+            const juce::String hexPlaceholderColor = value;
+            const juce::Colour placeholderColor = juce::Colour::fromString(hexPlaceholderColor);
             textInput.setPlaceholderColour(placeholderColor);
         }
+
         if (name == maxlengthProp)
         {
             if (!value.isDouble())
               throw std::invalid_argument("Invalid prop value. Prop \'maxlength\' must be a number.");
+
             textInput.setMaxLength(value);
         }
+
         if (name == readonly)
         {
             textInput.setReadOnly(value);
@@ -154,8 +154,8 @@ namespace blueprint
 
         textInput.applyFontToAllText(getFont());
 
-        juce::String hexColor = props.getWithDefault(colorProp, "ff000000");
-        juce::Colour colour = juce::Colour::fromString(hexColor);
+        const juce::String hexColor = props.getWithDefault(colorProp, "ff000000");
+        const juce::Colour colour = juce::Colour::fromString(hexColor);
         textInput.applyColourToAllText(colour);
 
         const int just = props.getWithDefault(justificationProp, 1);
@@ -171,28 +171,28 @@ namespace blueprint
         textInput.setBounds(getLocalBounds());
     }
 
-    juce::Font TextInputView::getFont()
+    juce::Font TextInputView::getFont() const
     {
         return TextView::getFont(props);
     }
 
     bool TextInputView::isTextEditorColorProp(const juce::Identifier &textEditorColorProp)
     {
-        auto it = textEditorColourIdsByProp.find(textEditorColorProp);
-        bool found = (it != textEditorColourIdsByProp.end());
-        return found;
+        const auto it = textEditorColourIdsByProp.find(textEditorColorProp);
+        return it != textEditorColourIdsByProp.end();
     }
 
     void TextInputView::setTextEditorColorProp(const juce::Identifier &textEditorColorProp, const juce::var &value)
     {
         if (!value.isString())
         {
-            std::string propName = textEditorColorProp.toString().toStdString();
-            std::string message = "Invalid prop value. Prop \'" + propName + "\' must be a color string.";
+            const std::string propName = textEditorColorProp.toString().toStdString();
+            const std::string message = "Invalid prop value. Prop \'" + propName + "\' must be a color string.";
             throw std::invalid_argument(message);
         }
-        juce::String hexColor = value;
-        juce::Colour color = juce::Colour::fromString(hexColor);
+
+        const juce::String hexColor = value;
+        const juce::Colour color = juce::Colour::fromString(hexColor);
         textInput.setColour(textEditorColourIdsByProp.at(textEditorColorProp), color);
     }
 

--- a/react_juce/core/TextInputView.cpp
+++ b/react_juce/core/TextInputView.cpp
@@ -10,7 +10,7 @@
 #include "TextInputView.h"
 #include "TextView.h"
 
-namespace blueprint
+namespace reactjuce
 {
     namespace detail
     {

--- a/react_juce/core/TextInputView.cpp
+++ b/react_juce/core/TextInputView.cpp
@@ -1,0 +1,225 @@
+/*
+==============================================================================
+
+  TextInputView.cpp
+  Created: 20 Jan 2021 10:30pm
+
+==============================================================================
+*/
+
+#include "TextInputView.h"
+#include "TextView.h"
+
+namespace blueprint
+{
+    namespace detail
+    {
+        static juce::var makeInputEventObject(const juce::String &value)
+        {
+            juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+            obj->setProperty("value", value);
+            return obj.get();
+        }
+
+        static juce::var makeChangeEventObject(const juce::String &value)
+        {
+            juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+            obj->setProperty("value", value);
+            return obj.get();
+        }
+    }
+
+    void TextInput::setControlledValue(const juce::String &value)
+    {
+        insertedAsControlledValue = true;
+        setText(value);
+    }
+
+    void TextInput::setMaxLength(int maxLen)
+    {
+        maxLength = maxLen;
+        setInputRestrictions(maxLen);
+    }
+
+    void TextInput::setPlaceholderText(const juce::String &text)
+    {
+        placeholderText = text;
+        setTextToShowWhenEmpty(placeholderText, placeholderColour);
+    }
+
+    void TextInput::setPlaceholderColour(const juce::Colour &colourToUse)
+    {
+        placeholderColour = colourToUse;
+        setTextToShowWhenEmpty(placeholderText, placeholderColour);
+    }
+
+    void TextInput::insertTextAtCaret(const juce::String &textToInsert)
+    {
+        juce::String currentValue = getText();
+        juce::TextEditor::insertTextAtCaret(textToInsert);
+        juce::String newValue = getText();
+        if (currentValue == newValue)
+        {
+            return;
+        }
+
+        // Invoke JavaScript's `input` event.
+        if ((*props).contains(TextInputView::onInputProp) && (*props)[TextInputView::onInputProp].isMethod())
+        {
+            std::array<juce::var, 1> args{{detail::makeInputEventObject(newValue)}};
+            juce::var::NativeFunctionArgs nfArgs(juce::var(), args.data(), static_cast<int>(args.size()));
+            std::invoke((*props)[TextInputView::onInputProp].getNativeFunction(), nfArgs);
+        }
+
+        dirty = true;
+
+        if (controlled && !insertedAsControlledValue)
+        {
+            undo();
+        }
+        insertedAsControlledValue = false;
+    }
+
+    //==============================================================================
+
+    void TextInput::textEditorReturnKeyPressed(juce::TextEditor &)
+    {
+        invokeChangeEventIfNeeded();
+    }
+
+    void TextInput::textEditorFocusLost(juce::TextEditor &)
+    {
+        invokeChangeEventIfNeeded();
+    }
+
+    void TextInput::invokeChangeEventIfNeeded()
+    {
+        if (dirty)
+        {
+            // Invoke JavaScript's `change` event.
+            if ((*props).contains(TextInputView::onChangeProp) && (*props)[TextInputView::onChangeProp].isMethod())
+            {
+                std::array<juce::var, 1> args{{detail::makeChangeEventObject(getText())}};
+                juce::var::NativeFunctionArgs nfArgs(juce::var(), args.data(), static_cast<int>(args.size()));
+                std::invoke((*props)[TextInputView::onChangeProp].getNativeFunction(), nfArgs);
+            }
+            dirty = false;
+        }
+    }
+
+    //==============================================================================
+
+    TextInputView::TextInputView()
+        : textInput(&props)
+    {
+        addAndMakeVisible(textInput);
+        textInput.addListener(&textInput);
+        textInput.setPopupMenuEnabled(false);
+    }
+
+    void TextInputView::setProperty(const juce::Identifier &name, const juce::var &value)
+    {
+        View::setProperty(name, value);
+        if (name == valueProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'value\' must be a string.");
+            textInput.setControlled(true);
+            textInput.setControlledValue(value);
+        }
+        if (name == placeholderProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'placeholder\' must be a string.");
+            textInput.setPlaceholderText(value);
+        }
+        if (name == placeholderColorProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'placeholder-color\' must be a color string.");
+            juce::String hexPlaceholderColor = value;
+            juce::Colour placeholderColor = juce::Colour::fromString(hexPlaceholderColor);
+            textInput.setPlaceholderColour(placeholderColor);
+        }
+        if (name == maxlengthProp)
+        {
+            if (!value.isDouble())
+              throw std::invalid_argument("Invalid prop value. Prop \'maxlength\' must be a number.");
+            textInput.setMaxLength(value);
+        }
+        if (name == readonly)
+        {
+            textInput.setReadOnly(value);
+        }
+
+        textInput.applyFontToAllText(getFont());
+
+        juce::String hexColor = props.getWithDefault(colorProp, "ff000000");
+        juce::Colour colour = juce::Colour::fromString(hexColor);
+        textInput.applyColourToAllText(colour);
+
+        int just = props.getWithDefault(justificationProp, 1);
+        textInput.setJustification(just);
+
+        juce::String hexBackgroundColor = props.getWithDefault(backgroundColorProp, "00000000");
+        juce::Colour backgroundColour = juce::Colour::fromString(hexBackgroundColor);
+        textInput.setColour(juce::TextEditor::ColourIds::backgroundColourId, backgroundColour);
+
+        if (name == outlineColorProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'outline-color\' must be a color string.");
+            juce::String hexOutlineColor = value;
+            juce::Colour outlineColor = juce::Colour::fromString(hexOutlineColor);
+            textInput.setColour(juce::TextEditor::ColourIds::outlineColourId, outlineColor);
+        }
+        if (name == focusedOutlineColorProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'focused-outline-color\' must be a color string.");
+            juce::String hexFocusedOutlineColor = value;
+            juce::Colour focusedOutlineColor = juce::Colour::fromString(hexFocusedOutlineColor);
+            textInput.setColour(juce::TextEditor::ColourIds::focusedOutlineColourId, focusedOutlineColor);
+        }
+        if (name == highlightedTextColorProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'highlighted-text-color\' must be a color string.");
+            juce::String hexHighlightedTextColor = value;
+            juce::Colour highlightedTextColor = juce::Colour::fromString(hexHighlightedTextColor);
+            textInput.setColour(juce::TextEditor::ColourIds::highlightedTextColourId, highlightedTextColor);
+        }
+        if (name == highlightColorProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'highlight-color\' must be a color string.");
+            juce::String hexHighlightColor = value;
+            juce::Colour highlightColor = juce::Colour::fromString(hexHighlightColor);
+            textInput.setColour(juce::TextEditor::ColourIds::highlightColourId, highlightColor);
+        }
+        if (name == caretColorProp)
+        {
+            if (!value.isString())
+                throw std::invalid_argument("Invalid prop value. Prop \'caret-color\' must be a color string.");
+            juce::String hexCaretColor = value;
+            juce::Colour caretColor = juce::Colour::fromString(hexCaretColor);
+            textInput.setColour(juce::CaretComponent::ColourIds::caretColourId, caretColor);
+        }
+    }
+
+    void TextInputView::paint(juce::Graphics &g)
+    {
+        View::paint(g);
+    }
+
+    void TextInputView::resized()
+    {
+        View::resized();
+        textInput.setBounds(0, 0, getWidth(), getHeight());
+    }
+
+    juce::Font TextInputView::getFont()
+    {
+        return TextView::getFont(props);
+    }
+}

--- a/react_juce/core/TextInputView.cpp
+++ b/react_juce/core/TextInputView.cpp
@@ -161,50 +161,8 @@ namespace blueprint
         const int just = props.getWithDefault(justificationProp, 1);
         textInput.setJustification(just);
 
-        juce::String hexBackgroundColor = props.getWithDefault(backgroundColorProp, "00000000");
-        juce::Colour backgroundColour = juce::Colour::fromString(hexBackgroundColor);
-        textInput.setColour(juce::TextEditor::ColourIds::backgroundColourId, backgroundColour);
-
-        if (name == outlineColorProp)
-        {
-            if (!value.isString())
-                throw std::invalid_argument("Invalid prop value. Prop \'outline-color\' must be a color string.");
-            juce::String hexOutlineColor = value;
-            juce::Colour outlineColor = juce::Colour::fromString(hexOutlineColor);
-            textInput.setColour(juce::TextEditor::ColourIds::outlineColourId, outlineColor);
-        }
-        if (name == focusedOutlineColorProp)
-        {
-            if (!value.isString())
-                throw std::invalid_argument("Invalid prop value. Prop \'focused-outline-color\' must be a color string.");
-            juce::String hexFocusedOutlineColor = value;
-            juce::Colour focusedOutlineColor = juce::Colour::fromString(hexFocusedOutlineColor);
-            textInput.setColour(juce::TextEditor::ColourIds::focusedOutlineColourId, focusedOutlineColor);
-        }
-        if (name == highlightedTextColorProp)
-        {
-            if (!value.isString())
-                throw std::invalid_argument("Invalid prop value. Prop \'highlighted-text-color\' must be a color string.");
-            juce::String hexHighlightedTextColor = value;
-            juce::Colour highlightedTextColor = juce::Colour::fromString(hexHighlightedTextColor);
-            textInput.setColour(juce::TextEditor::ColourIds::highlightedTextColourId, highlightedTextColor);
-        }
-        if (name == highlightColorProp)
-        {
-            if (!value.isString())
-                throw std::invalid_argument("Invalid prop value. Prop \'highlight-color\' must be a color string.");
-            juce::String hexHighlightColor = value;
-            juce::Colour highlightColor = juce::Colour::fromString(hexHighlightColor);
-            textInput.setColour(juce::TextEditor::ColourIds::highlightColourId, highlightColor);
-        }
-        if (name == caretColorProp)
-        {
-            if (!value.isString())
-                throw std::invalid_argument("Invalid prop value. Prop \'caret-color\' must be a color string.");
-            juce::String hexCaretColor = value;
-            juce::Colour caretColor = juce::Colour::fromString(hexCaretColor);
-            textInput.setColour(juce::CaretComponent::ColourIds::caretColourId, caretColor);
-        }
+        if (isTextEditorColorProp(name))
+            setTextEditorColorProp(name, value);
     }
 
     void TextInputView::resized()
@@ -217,4 +175,33 @@ namespace blueprint
     {
         return TextView::getFont(props);
     }
+
+    bool TextInputView::isTextEditorColorProp(const juce::Identifier &textEditorColorProp)
+    {
+        auto it = textEditorColourIdsByProp.find(textEditorColorProp);
+        bool found = (it != textEditorColourIdsByProp.end());
+        return found;
+    }
+
+    void TextInputView::setTextEditorColorProp(const juce::Identifier &textEditorColorProp, const juce::var &value)
+    {
+        if (!value.isString())
+        {
+            std::string propName = textEditorColorProp.toString().toStdString();
+            std::string message = "Invalid prop value. Prop \'" + propName + "\' must be a color string.";
+            throw std::invalid_argument(message);
+        }
+        juce::String hexColor = value;
+        juce::Colour color = juce::Colour::fromString(hexColor);
+        textInput.setColour(textEditorColourIdsByProp.at(textEditorColorProp), color);
+    }
+
+    const std::map<juce::Identifier, int> TextInputView::textEditorColourIdsByProp = {
+        { backgroundColorProp,      juce::TextEditor::ColourIds::backgroundColourId },
+        { outlineColorProp,         juce::TextEditor::ColourIds::outlineColourId },
+        { focusedOutlineColorProp,  juce::TextEditor::ColourIds::focusedOutlineColourId },
+        { highlightedTextColorProp, juce::TextEditor::ColourIds::highlightedTextColourId },
+        { highlightColorProp,       juce::TextEditor::ColourIds::highlightColourId },
+        { caretColorProp,           juce::CaretComponent::ColourIds::caretColourId }
+    };
 }

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -37,14 +37,13 @@ namespace blueprint
     public:
         //==============================================================================
         explicit TextInput(const juce::NamedValueSet &_props)
-            :
-            props(_props),
-            controlled(false),
-            insertedAsControlledValue(false),
-            dirty(false),
-            maxLength(INT_MAX),
-            placeholderText(),
-            placeholderColour(juce::Colours::black) {}
+            : props(_props)
+            , controlled(false)
+            , insertedAsControlledValue(false)
+            , dirty(false)
+            , maxLength(INT_MAX)
+            , placeholderText()
+            , placeholderColour(juce::Colours::black) {}
 
         void insertTextAtCaret(const juce::String &textToInsert) override;
         void setControlled(bool _controlled) { controlled = _controlled; }
@@ -99,13 +98,19 @@ namespace blueprint
         static const inline juce::Identifier onChangeProp = "onChange";
 
         //==============================================================================
-        TextInputView();
+        TextInputView()
+            : textInput(props)
+        {
+            addAndMakeVisible(textInput);
+            textInput.addListener(&textInput);
+            textInput.setPopupMenuEnabled(false);
+        }
         void setProperty(const juce::Identifier &name, const juce::var &value) override;
         void resized() override;
 
     private:
         //==============================================================================
-        juce::Font getFont();
+        juce::Font getFont() const;
         static bool isTextEditorColorProp(const juce::Identifier &textEditorColorProp);
         void setTextEditorColorProp(const juce::Identifier &textEditorColorProp, const juce::var &value);
 

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -106,9 +106,12 @@ namespace blueprint
     private:
         //==============================================================================
         juce::Font getFont();
+        static bool isTextEditorColorProp(const juce::Identifier &textEditorColorProp);
+        void setTextEditorColorProp(const juce::Identifier &textEditorColorProp, const juce::var &value);
 
         //==============================================================================
         TextInput textInput;
+        static const std::map<juce::Identifier, int> textEditorColourIdsByProp;
 
         //==============================================================================
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TextInputView)

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -36,7 +36,7 @@ namespace blueprint
     {
     public:
         //==============================================================================
-        explicit TextInput(const juce::NamedValueSet *_props)
+        explicit TextInput(const juce::NamedValueSet &_props)
             :
             props(_props),
             controlled(false),
@@ -61,7 +61,7 @@ namespace blueprint
         void invokeChangeEventIfNeeded();
 
         //==============================================================================
-        const juce::NamedValueSet *props;
+        const juce::NamedValueSet &props;
         bool controlled;
         bool insertedAsControlledValue;
 
@@ -84,10 +84,10 @@ namespace blueprint
         static const inline juce::Identifier colorProp = "color";
         static const inline juce::Identifier justificationProp = "justification";
 
-        static inline juce::Identifier placeholderProp = "placeholder";
-        static inline juce::Identifier placeholderColorProp = "placeholder-color";
-        static inline juce::Identifier maxlengthProp = "maxlength";
-        static inline juce::Identifier readonly = "readonly";
+        static const inline juce::Identifier placeholderProp = "placeholder";
+        static const inline juce::Identifier placeholderColorProp = "placeholder-color";
+        static const inline juce::Identifier maxlengthProp = "maxlength";
+        static const inline juce::Identifier readonly = "readonly";
 
         static const inline juce::Identifier outlineColorProp = "outline-color";
         static const inline juce::Identifier focusedOutlineColorProp = "focused-outline-color";
@@ -95,13 +95,12 @@ namespace blueprint
         static const inline juce::Identifier highlightColorProp = "highlight-color";
         static const inline juce::Identifier caretColorProp = "caret-color";
 
-        static inline juce::Identifier onInputProp = "onInput";
-        static inline juce::Identifier onChangeProp = "onChange";
+        static const inline juce::Identifier onInputProp = "onInput";
+        static const inline juce::Identifier onChangeProp = "onChange";
 
         //==============================================================================
         TextInputView();
         void setProperty(const juce::Identifier &name, const juce::var &value) override;
-        void paint(juce::Graphics &g) override;
         void resized() override;
 
     private:

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -14,68 +14,71 @@
 namespace blueprint
 {
     //==============================================================================
-    /** The TextInput class is an extended juce::TextEditor class for TextInputView
-     * class. There are some features added.
-     *
-     * - Invoke JavaScript's 'input' and 'change' event.
-     *
-     *   Note: React.js has only 'onChange' callback which has same behavior as
-     *   JavaScript's 'onInput' and does not have any callback corresponding to
-     *   original JavaScript's 'onChange'.
-     *   https://stackoverflow.com/questions/38256332/in-react-whats-the-difference-between-onchange-and-oninput
-     *
-     * - Support React's controlled component model.
-     *   https://reactjs.org/docs/uncontrolled-components.html
-     *   If field `controlled` is true,
-     *   only the string value given by `setControlledValue()`
-     *   is shown in the text editor.
-     *
-     * - Allow to set 'placeholder' text and 'placeholder-color' separately.
-     */
-    class TextInput : public juce::TextEditor, public juce::TextEditor::Listener
-    {
-    public:
-        //==============================================================================
-        explicit TextInput(const juce::NamedValueSet &_props)
-            : props(_props)
-            , controlled(false)
-            , insertedAsControlledValue(false)
-            , dirty(false)
-            , maxLength(INT_MAX)
-            , placeholderText()
-            , placeholderColour(juce::Colours::black) {}
-
-        void insertTextAtCaret(const juce::String &textToInsert) override;
-        void setControlled(bool _controlled) { controlled = _controlled; }
-        void setControlledValue(const juce::String &value);
-        void setMaxLength(int maxLen);
-        void setPlaceholderText(const juce::String &text);
-        void setPlaceholderColour(const juce::Colour &colourToUse);
-
-        //==============================================================================
-        void textEditorReturnKeyPressed(juce::TextEditor &) override;
-        void textEditorFocusLost(juce::TextEditor &) override;
-    private:
-        //==============================================================================
-        void invokeChangeEventIfNeeded();
-
-        //==============================================================================
-        const juce::NamedValueSet &props;
-        bool controlled;
-        bool insertedAsControlledValue;
-
-        bool dirty; // for `onChange`
-        int maxLength;
-        juce::String placeholderText;
-        juce::Colour placeholderColour;
-    };
-
-    //==============================================================================
     /** The TextInputView class is a core view for text editor
      * within Blueprint's layout system.
      */
     class TextInputView : public View
     {
+        //==============================================================================
+        /** The TextInput class is an extended juce::TextEditor class for TextInputView
+         * class. There are some features added.
+         *
+         * - Invoke JavaScript's 'input' and 'change' event.
+         *
+         *   Note: React.js has only 'onChange' callback which has same behavior as
+         *   JavaScript's 'onInput' and does not have any callback corresponding to
+         *   original JavaScript's 'onChange'.
+         *   https://stackoverflow.com/questions/38256332/in-react-whats-the-difference-between-onchange-and-oninput
+         *
+         * - Support React's controlled component model.
+         *   https://reactjs.org/docs/uncontrolled-components.html
+         *   If field `controlled` is true,
+         *   only the string value given by `setControlledValue()`
+         *   is shown in the text editor.
+         *
+         * - Allow to set 'placeholder' text and 'placeholder-color' separately.
+         */
+        class TextInput : public juce::TextEditor
+                        , public juce::TextEditor::Listener
+        {
+        public:
+            //==============================================================================
+            explicit TextInput(const juce::NamedValueSet &_props)
+                : props(_props)
+                , controlled(false)
+                , insertedAsControlledValue(false)
+                , dirty(false)
+                , maxLength(INT_MAX)
+                , placeholderText()
+                , placeholderColour(juce::Colours::black) {}
+
+            void insertTextAtCaret(const juce::String &textToInsert) override;
+            void setControlled(bool _controlled) { controlled = _controlled; }
+            void setControlledValue(const juce::String &value);
+            void setMaxLength(int maxLen);
+            void setPlaceholderText(const juce::String &text);
+            void setPlaceholderColour(const juce::Colour &colourToUse);
+
+            //==============================================================================
+            void textEditorReturnKeyPressed(juce::TextEditor &) override;
+            void textEditorFocusLost(juce::TextEditor &) override;
+        private:
+            //==============================================================================
+            void invokeChangeEventIfNeeded();
+
+            //==============================================================================
+            const juce::NamedValueSet &props;
+            bool controlled;
+            bool insertedAsControlledValue;
+
+            bool dirty; // for `onChange`
+            int maxLength;
+            juce::String placeholderText;
+            juce::Colour placeholderColour;
+        };
+
+        //==============================================================================
+
     public:
         //==============================================================================
         static inline juce::Identifier valueProp = "value";

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -11,7 +11,7 @@
 
 #include "View.h"
 
-namespace blueprint
+namespace reactjuce
 {
     //==============================================================================
     /** The TextInputView class is a core view for text editor

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -1,0 +1,118 @@
+/*
+==============================================================================
+
+  TextInputView.h
+  Created: 20 Jan 2021 10:30pm
+
+==============================================================================
+*/
+
+#pragma once
+
+#include "View.h"
+
+namespace blueprint
+{
+    //==============================================================================
+    /** The TextInput class is an extended juce::TextEditor class for TextInputView
+     * class. There are some features added.
+     *
+     * - Invoke JavaScript's 'input' and 'change' event.
+     *
+     *   Note: React.js has only 'onChange' callback which has same behavior as
+     *   JavaScript's 'onInput' and does not have any callback corresponding to
+     *   original JavaScript's 'onChange'.
+     *   https://stackoverflow.com/questions/38256332/in-react-whats-the-difference-between-onchange-and-oninput
+     *
+     * - Support React's controlled component model.
+     *   https://reactjs.org/docs/uncontrolled-components.html
+     *   If field `controlled` is true,
+     *   only the string value given by `setControlledValue()`
+     *   is shown in the text editor.
+     *
+     * - Allow to set 'placeholder' text and 'placeholder-color' separately.
+     */
+    class TextInput : public juce::TextEditor, public juce::TextEditor::Listener
+    {
+    public:
+        //==============================================================================
+        explicit TextInput(const juce::NamedValueSet *_props)
+            :
+            props(_props),
+            controlled(false),
+            insertedAsControlledValue(false),
+            dirty(false),
+            maxLength(INT_MAX),
+            placeholderText(),
+            placeholderColour(juce::Colours::black) {}
+
+        void insertTextAtCaret(const juce::String &textToInsert) override;
+        void setControlled(bool _controlled) { controlled = _controlled; }
+        void setControlledValue(const juce::String &value);
+        void setMaxLength(int maxLen);
+        void setPlaceholderText(const juce::String &text);
+        void setPlaceholderColour(const juce::Colour &colourToUse);
+
+        //==============================================================================
+        void textEditorReturnKeyPressed(juce::TextEditor &) override;
+        void textEditorFocusLost(juce::TextEditor &) override;
+    private:
+        //==============================================================================
+        void invokeChangeEventIfNeeded();
+
+        //==============================================================================
+        const juce::NamedValueSet *props;
+        bool controlled;
+        bool insertedAsControlledValue;
+
+        bool dirty; // for `onChange`
+        int maxLength;
+        juce::String placeholderText;
+        juce::Colour placeholderColour;
+    };
+
+    //==============================================================================
+    /** The TextInputView class is a core view for text editor
+     * within Blueprint's layout system.
+     */
+    class TextInputView : public View
+    {
+    public:
+        //==============================================================================
+        static inline juce::Identifier valueProp = "value";
+
+        static const inline juce::Identifier colorProp = "color";
+        static const inline juce::Identifier justificationProp = "justification";
+
+        static inline juce::Identifier placeholderProp = "placeholder";
+        static inline juce::Identifier placeholderColorProp = "placeholder-color";
+        static inline juce::Identifier maxlengthProp = "maxlength";
+        static inline juce::Identifier readonly = "readonly";
+
+        static const inline juce::Identifier outlineColorProp = "outline-color";
+        static const inline juce::Identifier focusedOutlineColorProp = "focused-outline-color";
+        static const inline juce::Identifier highlightedTextColorProp = "highlighted-text-color";
+        static const inline juce::Identifier highlightColorProp = "highlight-color";
+        static const inline juce::Identifier caretColorProp = "caret-color";
+
+        static inline juce::Identifier onInputProp = "onInput";
+        static inline juce::Identifier onChangeProp = "onChange";
+
+        //==============================================================================
+        TextInputView();
+        void setProperty(const juce::Identifier &name, const juce::var &value) override;
+        void paint(juce::Graphics &g) override;
+        void resized() override;
+
+    private:
+        //==============================================================================
+        juce::Font getFont();
+
+        //==============================================================================
+        TextInput textInput;
+
+        //==============================================================================
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TextInputView)
+    };
+
+}

--- a/react_juce/core/TextInputView.h
+++ b/react_juce/core/TextInputView.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <climits>
 #include "View.h"
 
 namespace reactjuce

--- a/react_juce/core/TextView.h
+++ b/react_juce/core/TextView.h
@@ -38,19 +38,25 @@ namespace reactjuce
         TextView() = default;
 
         //==============================================================================
-        /** Assembles a Font from the current node properties. */
-        juce::Font getFont()
+        /** Assembles a Font from properties. */
+        static juce::Font getFont(const juce::NamedValueSet &_props)
         {
-            float fontHeight = props.getWithDefault(fontSizeProp, 12.0f);
-            int textStyleFlags = props.getWithDefault(fontStyleProp, 0);
+            float fontHeight = _props.getWithDefault(fontSizeProp, 12.0f);
+            int textStyleFlags = _props.getWithDefault(fontStyleProp, 0);
 
             juce::Font f (fontHeight);
 
-            if (props.contains(fontFamilyProp))
-                f = juce::Font (props[fontFamilyProp], fontHeight, textStyleFlags);
+            if (_props.contains(fontFamilyProp))
+                f = juce::Font (_props[fontFamilyProp], fontHeight, textStyleFlags);
 
-            f.setExtraKerningFactor(props.getWithDefault(kerningFactorProp, 0.0));
+            f.setExtraKerningFactor(_props.getWithDefault(kerningFactorProp, 0.0));
             return f;
+        }
+
+        /** Assembles a Font from the current node properties. */
+        juce::Font getFont()
+        {
+            return getFont(props);
         }
 
         /** Constructs a TextLayout from all the children string values. */

--- a/react_juce/core/TextView.h
+++ b/react_juce/core/TextView.h
@@ -39,17 +39,17 @@ namespace reactjuce
 
         //==============================================================================
         /** Assembles a Font from properties. */
-        static juce::Font getFont(const juce::NamedValueSet &_props)
+        static juce::Font getFont(const juce::NamedValueSet &fontProps)
         {
-            float fontHeight = _props.getWithDefault(fontSizeProp, 12.0f);
-            int textStyleFlags = _props.getWithDefault(fontStyleProp, 0);
+            const float fontHeight = fontProps.getWithDefault(fontSizeProp, 12.0f);
+            const int textStyleFlags = fontProps.getWithDefault(fontStyleProp, 0);
 
             juce::Font f (fontHeight);
 
-            if (_props.contains(fontFamilyProp))
-                f = juce::Font (_props[fontFamilyProp], fontHeight, textStyleFlags);
+            if (fontProps.contains(fontFamilyProp))
+                f = juce::Font (fontProps[fontFamilyProp], fontHeight, textStyleFlags);
 
-            f.setExtraKerningFactor(_props.getWithDefault(kerningFactorProp, 0.0));
+            f.setExtraKerningFactor(fontProps.getWithDefault(kerningFactorProp, 0.0));
             return f;
         }
 

--- a/react_juce/core/ViewManager.cpp
+++ b/react_juce/core/ViewManager.cpp
@@ -13,6 +13,7 @@
 #include "ScrollView.h"
 #include "ScrollViewContentShadowView.h"
 #include "TextView.h"
+#include "TextInputView.h"
 #include "TextShadowView.h"
 
 
@@ -44,6 +45,7 @@ namespace reactjuce
         // Register the default view types
         registerViewType("View", GenericViewFactory<View, ShadowView>());
         registerViewType("Text", GenericViewFactory<TextView, TextShadowView>());
+        registerViewType("TextInput", GenericViewFactory<TextInputView, ShadowView>());
         registerViewType("CanvasView", GenericViewFactory<CanvasView, ShadowView>());
         registerViewType("Image", GenericViewFactory<ImageView, ShadowView>());
         registerViewType("ScrollView", GenericViewFactory<ScrollView, ShadowView>());

--- a/react_juce/react_juce.cpp
+++ b/react_juce/react_juce.cpp
@@ -84,6 +84,7 @@
 #include "core/CanvasView.cpp"
 #include "core/ReactApplicationRoot.cpp"
 #include "core/ShadowView.cpp"
+#include "core/TextInputView.cpp"
 #include "core/TextShadowView.cpp"
 #include "core/View.cpp"
 #include "core/ViewManager.cpp"

--- a/react_juce/react_juce.h
+++ b/react_juce/react_juce.h
@@ -127,6 +127,7 @@
 #include "core/ShadowView.h"
 #include "core/TextShadowView.h"
 #include "core/TextView.h"
+#include "core/TextInputView.h"
 #include "core/Utils.h"
 #include "core/View.h"
 #include "core/ViewManager.h"


### PR DESCRIPTION
This PR is related to #21 .

## Summary
This PR allows you to use `TextInput` component which has similar behavior of `<input type="text">`.

<img width="448" alt="screenshot" src="https://user-images.githubusercontent.com/54586159/105618723-fa407680-5e2d-11eb-993e-79c56e88c712.png">

## Features
- React's controlled components model (when `value` prop is provided)
- `OnInput` and `OnChange` callback
- Some basic properties. `fontSize`, `placeholder`, `maxlength`, etc.
- `juce::TextEditor`'s properties. e.g. 'highlight-color' which can be set by 
  `juce::Component::setColour()` in original JUCE