### PR TITLE
Implement dispatch event to pass gain level values to Meter component

### DIFF
--- a/examples/GainPlugin/PluginProcessor.cpp
+++ b/examples/GainPlugin/PluginProcessor.cpp
@@ -166,6 +166,9 @@ void GainPluginAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuf
         if (muted)
             buffer.applyGain(0.0f);
     }
+    
+    // Read current block gain peak value
+    gainPeakValue = buffer.getMagnitude (0, buffer.getNumSamples());
 }
 
 //==============================================================================

--- a/examples/GainPlugin/PluginProcessor.cpp
+++ b/examples/GainPlugin/PluginProcessor.cpp
@@ -47,6 +47,11 @@ GainPluginAudioProcessor::GainPluginAudioProcessor()
 {
 }
 
+GainPluginAudioProcessor::~GainPluginAudioProcessor()
+{
+    Timer::stopTimer();
+}
+
 //==============================================================================
 const String GainPluginAudioProcessor::getName() const
 {
@@ -186,8 +191,23 @@ AudioProcessorEditor* GainPluginAudioProcessor::createEditor()
     editor->setResizeLimits(400, 240, 400 * 2, 240 * 2);
     editor->getConstrainer()->setFixedAspectRatio(400.0 / 240.0);
     editor->setSize (400, 240);
+    
+    // Get appRoot reference created by GenericEditor in order to dispatch events
+    appRoot = &editor->getReactAppRoot();
+    // Start timer to dispatch gainPeakValues event to update Meter values
+    Timer::startTimer(100);
 
     return editor;
+}
+
+void GainPluginReactAudioProcessor::timerCallback()
+{
+    // Dispatch gainPeakValues event used by Meter React component
+    appRoot->dispatchEvent(
+        "gainPeakValues",
+        static_cast<float>(gainPeakValue),
+        static_cast<float>(gainPeakValue)
+    );
 }
 
 //==============================================================================

--- a/examples/GainPlugin/PluginProcessor.cpp
+++ b/examples/GainPlugin/PluginProcessor.cpp
@@ -195,8 +195,6 @@ AudioProcessorEditor* GainPluginAudioProcessor::createEditor()
     editor->getConstrainer()->setFixedAspectRatio(400.0 / 240.0);
     editor->setSize (400, 240);
     
-    // Get appRoot reference created by GenericEditor in order to dispatch events
-    appRoot = &editor->getReactAppRoot();
     // Start timer to dispatch gainPeakValues event to update Meter values
     Timer::startTimer(100);
 
@@ -205,12 +203,15 @@ AudioProcessorEditor* GainPluginAudioProcessor::createEditor()
 
 void GainPluginReactAudioProcessor::timerCallback()
 {
-    // Dispatch gainPeakValues event used by Meter React component
-    appRoot->dispatchEvent(
-        "gainPeakValues",
-        static_cast<float>(gainPeakValue),
-        static_cast<float>(gainPeakValue)
-    );
+    if (auto* editor = dynamic_cast<reactjuce::GenericEditor*>(getActiveEditor()))
+    {
+        // Dispatch gainPeakValues event used by Meter React component
+        editor->getReactAppRoot().dispatchEvent(
+            "gainPeakValues",
+            static_cast<float>(gainPeakValue),
+            static_cast<float>(gainPeakValue)
+        );
+    }
 }
 
 //==============================================================================

--- a/examples/GainPlugin/PluginProcessor.h
+++ b/examples/GainPlugin/PluginProcessor.h
@@ -15,7 +15,7 @@
 //==============================================================================
 /**
 */
-class GainPluginAudioProcessor  : public AudioProcessor, public juce::Timer
+class GainPluginAudioProcessor  : public AudioProcessor, private Timer
 {
 public:
     //==============================================================================

--- a/examples/GainPlugin/PluginProcessor.h
+++ b/examples/GainPlugin/PluginProcessor.h
@@ -15,7 +15,7 @@
 //==============================================================================
 /**
 */
-class GainPluginAudioProcessor  : public AudioProcessor, public Timer
+class GainPluginAudioProcessor  : public AudioProcessor, public juce::Timer
 {
 public:
     //==============================================================================

--- a/examples/GainPlugin/PluginProcessor.h
+++ b/examples/GainPlugin/PluginProcessor.h
@@ -56,6 +56,8 @@ public:
 
     //==============================================================================
     AudioProcessorValueTreeState& getValueTreeState() { return params; }
+    
+    void timerCallback() override;
 
 private:
     //==============================================================================

--- a/examples/GainPlugin/PluginProcessor.h
+++ b/examples/GainPlugin/PluginProcessor.h
@@ -61,7 +61,6 @@ public:
 
 private:
     //==============================================================================
-    reactjuce::ReactApplicationRoot* appRoot;
     AudioProcessorValueTreeState params;
     LinearSmoothedValue<float> gain;
     std::atomic<float> gainPeakValue;

--- a/examples/GainPlugin/PluginProcessor.h
+++ b/examples/GainPlugin/PluginProcessor.h
@@ -15,7 +15,7 @@
 //==============================================================================
 /**
 */
-class GainPluginAudioProcessor  : public AudioProcessor
+class GainPluginAudioProcessor  : public AudioProcessor, public Timer
 {
 public:
     //==============================================================================
@@ -59,8 +59,10 @@ public:
 
 private:
     //==============================================================================
+    reactjuce::ReactApplicationRoot* appRoot;
     AudioProcessorValueTreeState params;
     LinearSmoothedValue<float> gain;
+    std::atomic<float> gainPeakValue;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GainPluginAudioProcessor)

--- a/react_juce/core/GenericEditor.h
+++ b/react_juce/core/GenericEditor.h
@@ -47,6 +47,9 @@ namespace reactjuce
         /** Override the component interface. */
         void resized() override;
         void paint (juce::Graphics&) override;
+        
+        /** Public getter to access appRoot instance */
+        ReactApplicationRoot& getReactAppRoot() { return appRoot; }
 
     private:
         //==============================================================================


### PR DESCRIPTION
Fixes Meter in GainPlugin example.


* Read `gainPeakValue` in processBlock.

* Initialise 100ms (arbitrary number) Timer to call `dispatchEvent` passing gain values to `Meter` component

* Add public `getReactAppRoot ` getter to `GenericEditor` in order to call `dispatchEvent` from `appRoot` instance created by it as suggested by Nick.