### PR TITLE
Fixes GCC builds treating warnings as errors due to unusued function …

### DIFF
--- a/react_juce/core/Utils.cpp
+++ b/react_juce/core/Utils.cpp
@@ -1,0 +1,26 @@
+/*
+  ==============================================================================
+
+    Utils.cpp
+    Created: 20 Jan 2021 10:44:27pm
+
+  ==============================================================================
+*/
+
+#include "Utils.h"
+
+namespace reactjuce
+{
+    namespace detail
+    {
+        juce::var makeErrorObject(const juce::String& errorName, const juce::String& errorMessage)
+        {
+            juce::DynamicObject::Ptr o = new juce::DynamicObject();
+
+            o->setProperty("name", errorName);
+            o->setProperty("message", errorMessage);
+
+            return o.get();
+        }
+    }
+}

--- a/react_juce/core/Utils.h
+++ b/react_juce/core/Utils.h
@@ -13,14 +13,7 @@ namespace reactjuce
 {
     namespace detail
     {
-        static juce::var makeErrorObject(const juce::String& errorName, const juce::String& errorMessage)
-        {
-            auto* o = new juce::DynamicObject();
-
-            o->setProperty("name", errorName);
-            o->setProperty("message", errorMessage);
-
-            return juce::var(o);
-        }
+        // Constructs a generic error object to pass through to JS
+        juce::var makeErrorObject(const juce::String& errorName, const juce::String& errorMessage);
     }
 }

--- a/react_juce/react_juce.cpp
+++ b/react_juce/react_juce.cpp
@@ -89,3 +89,4 @@
 #include "core/ViewManager.cpp"
 #include "core/ScrollView.cpp"
 #include "core/ImageView.cpp"
+#include "core/Utils.cpp"


### PR DESCRIPTION
…makeErrorObject.

    We could have makeErrorObject be "static inline" but doesn't really
    make sense to inline this function imho. Just move the util/helper
    function definitions into cpp.