### PR TITLE
Fixes publishing of all TS types

### DIFF
--- a/packages/react-juce/package.json
+++ b/packages/react-juce/package.json
@@ -10,7 +10,10 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/index.js",
-    "dist/index.d.ts"
+    "dist/index.d.ts",
+    "dist/lib",
+    "dist/components",
+    "dist/src"
   ],
   "author": "Nick Thompson",
   "devDependencies": {


### PR DESCRIPTION
    We had added index.d.ts to the whiltelist of files to publish but
    that definnition file imports other definitions which need to be
    included in the package.