### PR TITLE
Fix CanvasView assertion when stateful and component has 0 width/height.

### DIFF
--- a/react_juce/core/CanvasView.cpp
+++ b/react_juce/core/CanvasView.cpp
@@ -656,9 +656,12 @@ namespace reactjuce
         //      May require passing an optional scaleFactor
         //      arg through to draw commands.
         const auto bounds = getLocalBounds();
-        canvasImage = canvasImage.rescaled(bounds.getWidth(),
-                                           bounds.getHeight(),
-                                           juce::Graphics::highResamplingQuality);
+        if (bounds.getWidth() > 0 && bounds.getHeight() > 0)
+        {
+            canvasImage = canvasImage.rescaled(bounds.getWidth(),
+                                               bounds.getHeight(),
+                                               juce::Graphics::highResamplingQuality);
+        }
     }
 
     //==============================================================================


### PR DESCRIPTION
@nick-thompson, This fixes the assert people have been mentioning on Discord. 

Think this simple check is enough. I've tested this by switching the `stateful` prop on the animated Canvas element in the example plugin. Resizing of the canvas image appears to work as expected including when width/height drops to 0. 